### PR TITLE
Add Texas Business Grants to Startups section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Only official program pages are listed.
 | [Retool for Startups](https://retool.com/startups) | Retool | Free Retool access for early-stage startups (up to ~$60k value) |
 | [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Get up to $5,000 in credits and priority support |
 | [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation + partner perks |
+| [Texas Business Grants](https://texasbusinessgrants.com) | Texas Business Grants | Free grant matching for Texas startups (120+ programs) |
 | [Vercel Startups](https://vercel.com/startups) | Vercel | Hosting credits |
 | [Y Combinator](https://www.ycombinator.com) | Y Combinator | Up to $500.000 |
 | [ZAI Startups](https://startup.z.ai/) | Z Ai | Free API Credits ZAI model |


### PR DESCRIPTION
## What

Adds [Texas Business Grants](https://texasbusinessgrants.com) to the **Startups** section.

## About the program

Texas Business Grants is a free grant-matching tool for Texas startups and small businesses. It screens businesses against 120+ government grants, tax credits, loans, and incentive programs and shows them which ones they qualify for.

Unlike the cloud-credit and SaaS programs in this list, this is a free tool that helps startups discover government funding they may not know about.

## Checklist

- [x] Links to the official program page
- [x] Program is active
- [x] Entry is alphabetically sorted within the section
- [x] Follows the table format
- [x] No affiliate or referral links