### PR TITLE
Correct Clerk for Startups benefit description

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Only official program pages are listed.
 |---|---|---|
 | [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Cloud credits (up to $100k) |
 | [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Get up to $250,000 in Cloudflare credits |
-| [Clerk for Startups](https://clerk.com/startups) | Clerk | Authentication infrastructure credits |
+| [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro at a discount for early-stage startups |
 | [Daytona](https://www.daytona.io/startups) | Daytona | $50k in Daytona credits |
 | [Datadog for Startups](https://www.datadoghq.com/partner/datadog-for-startups/) | Datadog | A year of free Datadog Pro |
 | [Google Cloud AI Startup Program](https://cloud.google.com/startup/ai) | Google | AI startup credits (up to $350k) |


### PR DESCRIPTION
Small accuracy fix: the Clerk for Startups program offers Clerk Pro at a discount for early-stage startups (up to 1 year after launch, up to $5M in funding) rather than infrastructure credits — details at https://clerk.com/startups. Updated the Benefit cell to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Clerk for Startups program listing to reflect discounted Clerk Pro access for early-stage startups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->