### PR TITLE
Add Atlas Cloud, Catalyst, NVIDIA, OVHcloud, Ona, Nebius, DigitalOcean Hatch, AssemblyAI, Deepgram

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Only official program pages are listed.
 | [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max |
 | [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects |
 | [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects |
+| [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/mo AI credits for OSS maintainers and contributors |
 | [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | 6 months of ChatGPT Pro with Codex, plus API credits |
 | [Upstash for Open Source](https://upstash.com/open-source) | Upstash | $1,000 monthly credit grant |
 
@@ -69,6 +70,7 @@ Only official program pages are listed.
 
 | Program | Provider | Benefit |
 |---|---|---|
+| [AssemblyAI Startup Program](https://www.assemblyai.com/contact/startup-program) | AssemblyAI | 12 months free credits for voice/speech AI |
 | [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Cloud credits (up to $100k) |
 | [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits |
 | [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits |
@@ -76,7 +78,9 @@ Only official program pages are listed.
 | [Databricks Startup Program](https://www.databricks.com/product/startups) | Databricks | Up to $200k in credits across Databricks and Neon |
 | [Daytona](https://www.daytona.io/startups) | Daytona | Up to $50k in Daytona credits |
 | [Datadog for Startups](https://www.datadoghq.com/partner/datadog-for-startups/) | Datadog | A year of free Datadog Pro |
+| [Deepgram for Startups](https://deepgram.com/startup-program) | Deepgram | Up to $100,000 in voice AI credits |
 | [Devin for Startups](https://devin.ai/startups) | Cognition (Devin) | $65,000 in credits and grants, direct support, free swag |
+| [DigitalOcean Hatch](https://www.digitalocean.com/startups) | DigitalOcean | Up to $100,000 in cloud credits |
 | [Google Cloud AI Startup Program](https://cloud.google.com/startup/ai) | Google | AI startup credits (up to $350k) |
 | [Google Cloud Startup Program](https://cloud.google.com/startup) | Google | Cloud credits and support |
 | [Kiro for Startups](https://kiro.dev/blog/bringing-back-startup-credits/) | Kiro (AWS) | Up to 1 year of Kiro Pro+ credits |
@@ -84,6 +88,7 @@ Only official program pages are listed.
 | [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | First year of Mixpanel free |
 | [Modal](https://modal.com/startups) | Modal | Free credits and technical support |
 | [Miro for Startups](https://miro.com/startups/) | Miro | $500–$1,000 in credits |
+| [Nebius for Startups](https://nebius.com/startups) | Nebius | $5,000 AI credits + discounts on GPU compute |
 | [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) |
 | [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free program: partner cloud credits, training, preferred GPU/software pricing |
 | [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000–€100,000 cloud credits + technical support |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Only official program pages are listed.
 | Program | Provider | Benefit |
 |---|---|---|
 | [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | Up to $1,500/mo AI credits (400+ models) for active OSS maintainers |
-| [Catalyst](https://www.opencoreventures.com/catalyst) | Open Core Ventures | $10,000 funding + 3-month mentorship for OSS projects |
+| [Catalyst](https://www.opencoreventures.com/catalyst) | Open Core Ventures | $10,000 sponsorship + 3-month program for eligible OSS authors and maintainers |
 | [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max |
 | [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects |
 | [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects |
@@ -91,7 +91,7 @@ Only official program pages are listed.
 | [Nebius for Startups](https://nebius.com/startups) | Nebius | $5,000 AI credits + discounts on GPU compute |
 | [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) |
 | [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free program: partner cloud credits, training, preferred GPU/software pricing |
-| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000–€100,000 cloud credits + technical support |
+| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000 for Start level; up to €100,000 for Scale level, plus technical support |
 | [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits |
 | [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) |
 | [Render](https://render.com/startups) | Render | Startup credits from $500 (Founder) up to $5,000+ depending on funding and partner tier |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Only official program pages are listed.
 | [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000 for Start level; up to €100,000 for Scale level, plus technical support |
 | [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits |
 | [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) |
-| [Render](https://render.com/startups) | Render | Startup credits from $500 (Founder) up to $5,000+ depending on funding and partner tier |
+| [Render](https://render.com/startups) | Render | Up to $100,000 in credits |
 | [Retool for Startups](https://retool.com/startups) | Retool | Free Retool access for early-stage startups |
 | [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Up to $5,000 in credits and priority support |
 | [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation and partner perks |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Only official program pages are listed.
 
 | Program | Provider | Benefit |
 |---|---|---|
+| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | Up to $1,500/mo AI credits (400+ models) for active OSS maintainers |
+| [Catalyst](https://www.opencoreventures.com/catalyst) | Open Core Ventures | $10,000 funding + 3-month mentorship for OSS projects |
 | [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max |
 | [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects |
 | [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects |
@@ -83,6 +85,8 @@ Only official program pages are listed.
 | [Modal](https://modal.com/startups) | Modal | Free credits and technical support |
 | [Miro for Startups](https://miro.com/startups/) | Miro | $500–$1,000 in credits |
 | [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) |
+| [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free program: partner cloud credits, training, preferred GPU/software pricing |
+| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000–€100,000 cloud credits + technical support |
 | [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits |
 | [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) |
 | [Render](https://render.com/startups) | Render | Startup credits from $500 (Founder) up to $5,000+ depending on funding and partner tier |


### PR DESCRIPTION
## Summary
Add high-quality active programs:

### Open Source
- **Atlas Cloud for Open Source** — Up to $1,500/mo AI credits
- **Catalyst** (Open Core Ventures) — $10k + mentorship
- **Ona for Open Source** — Up to $200/mo AI credits

### Startups
- **NVIDIA Inception** — Partner credits, training, preferred pricing
- **OVHcloud Startup Program** — €10k–€100k credits
- **Nebius for Startups** — $5k AI credits + GPU discounts
- **DigitalOcean Hatch** — Up to $100k cloud credits
- **AssemblyAI Startup Program** — 12 months free voice/speech credits
- **Deepgram for Startups** — Up to $100k voice AI credits

All link to official program pages.