### PR TITLE
Update Render + AWS Activate credit amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Only official program pages are listed.
 | [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) |
 | [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits |
 | [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) |
-| [Render](https://render.com/startups) | Render | Startup credits from $500 (Founder) up to $5,000+ depending on funding and partner tier |
+| [Render](https://render.com/startups) | Render | Up to $100,000 in credits (tiered by funding/partner) |
 | [Retool for Startups](https://retool.com/startups) | Retool | Free Retool access for early-stage startups |
 | [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Up to $5,000 in credits and priority support |
 | [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation and partner perks |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Only official program pages are listed.
 
 | Program | Provider | Benefit |
 |---|---|---|
-| [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Cloud credits (up to $100k) |
 | [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits |
 | [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits |
 | [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro at a discount for early-stage startups |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Only official program pages are listed.
 
 | Program | Provider | Benefit |
 |---|---|---|
+| [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Up to $200,000 in cloud credits (Portfolio; Founders up to $5k) |
 | [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits |
 | [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits |
 | [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro at a discount for early-stage startups |


### PR DESCRIPTION
## Changes
- **Render**: Up to $100,000 in credits (tiered by funding/partner) — confirmed by Render Startup Program
- **AWS Activate**: Up to $200,000 (Portfolio); Founders up to $5k — per official page