### PR TITLE
Cleanup paused listing and SOSF canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Only official program pages are listed.
 | [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects |
 | [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship + 3-month program for eligible OSS authors and maintainers |
 | [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max |
-| [GitHub Secure Open Source Fund](https://resources.github.com/github-secure-open-source-fund/) | GitHub | $10,000 per project, Copilot Pro, Azure credits, 3-week security program |
+| [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) | GitHub | $10,000 per project, Copilot Pro, Azure credits, 3-week security program |
 | [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects |
 | [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/mo AI credits for OSS maintainers and contributors |
 | [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | 6 months of ChatGPT Pro with Codex, plus API credits |
@@ -128,7 +128,6 @@ Only official program pages are listed.
 | [Cursor Campus Leads](https://cursor.com/campus-leads) | Cursor | 6 months Cursor Ultra and event funding (applications reopen January) |
 | [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Community benefits |
 | [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Credits and early access |
-| [OpenAI Codex Ambassadors](https://developers.openai.com/community/codex-ambassadors) | OpenAI | Credits and support (applications currently paused) |
 | [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | API credits ($50–$100/month) |
 
 ---


### PR DESCRIPTION
No listed program had an official shutdown page.

This PR only:
- Points GitHub Secure Open Source Fund at the canonical URL `https://github.com/open-source/github-secure-open-source-fund` (resources.github.com redirects there)
- Removes OpenAI Codex Ambassadors — official page still says applications are paused with no reopen date, so it is not currently claimable

Left in place: DigitalOcean student credits (page still indexed; no official wind-down on the DO URL).