### PR TITLE
Improve program accuracy and PR validation

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,22 @@
+name: Check links
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check Markdown links
+        uses: lycheeverse/lychee-action@v2.0.2
+        with:
+          args: --verbose --no-progress './**/*.md'
+          fail: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -18,5 +18,14 @@ jobs:
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2.0.2
         with:
-          args: --verbose --no-progress './**/*.md'
+          # These official pages reject or rate-limit automated requests.
+          args: >-
+            --verbose
+            --no-progress
+            --exclude 'https://chatgpt.com/codex/students'
+            --exclude 'https://openai.com/startups'
+            --exclude 'https://openai.com/student-collective/'
+            --exclude 'https://devin.ai/community'
+            --exclude 'https://devin.ai/startups'
+            './**/*.md'
           fail: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ This repository lists programs that provide **credits, grants, or tools** for st
 3. Add it in the correct section
 4. Keep entries **alphabetically sorted** by program name
 5. Follow the table format
+6. Confirm the link and benefit description immediately before opening the pull request
 
 Example:
 
@@ -24,6 +25,7 @@ Example:
 - No affiliate or referral links
 - Keep descriptions short
 - Do not add expired programs
+- Do not add programs whose applications are paused unless they are clearly marked in a dedicated paused-programs section
 - Note geographic or school eligibility limits when they apply
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Includes programs for:
 
 Only official program pages are listed.
 
+Program availability and benefits can change. Verify the provider page before applying.
+
 ---
 
 ## Contents
@@ -31,7 +33,6 @@ Only official program pages are listed.
 | Program | Provider | Benefit |
 |---|---|---|
 | [Codex for Students](https://chatgpt.com/codex/students) | OpenAI | $100 in Codex credits (US & Canada students only) |
-| [DigitalOcean Student Credits](https://www.digitalocean.com/github-students) | DigitalOcean | $200 platform credit for 1 year via GitHub Student Developer Pack |
 | [Figma for Education](https://www.figma.com/education/) | Figma | Free design tools for students |
 | [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | Developer tools bundle (~$10k value) |
 | [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | Free GitLab Ultimate for education |
@@ -40,7 +41,7 @@ Only official program pages are listed.
 | [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Free IDE licenses |
 | [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 credits/month free for 1 year (participating universities; SheerID verification) |
 | [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Paid remote OSS mentorship (stipends vary by region) |
-| [Manus Campus for Students](https://manus.im/edu) | Manus | Campus access; earn 1,000 credits for each student you invite |
+| [Manus Campus for Students](https://manus.im/edu) | Manus | Campus access; 1,000-credit referral reward per invited student |
 | [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | Azure credits and dev tools |
 | [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote fellowship with stipend |
 | [OpenAI Student Collective](https://openai.com/student-collective/) | OpenAI | Campus Lead role: ChatGPT + Codex credits, event funding, and stipend |
@@ -59,7 +60,7 @@ Only official program pages are listed.
 | [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects |
 | [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship + 3-month program for eligible OSS authors and maintainers |
 | [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max |
-| [GitHub Secure Open Source Fund](https://resources.github.com/github-secure-open-source-fund/) | GitHub | $10,000 per project, Copilot Pro, Azure credits, 3-week security program |
+| [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) | GitHub | $10,000 project funding, $10,000 Azure credits, Copilot Pro, and a 3-week security program |
 | [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects |
 | [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/mo AI credits for OSS maintainers and contributors |
 | [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | 6 months of ChatGPT Pro with Codex, plus API credits |
@@ -103,7 +104,7 @@ Only official program pages are listed.
 | [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation and partner perks |
 | [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 Temporal Cloud credits (funded startups, $30M or less raised) |
 | [Vercel Startups](https://vercel.com/startups) | Vercel | Hosting credits |
-| [Y Combinator](https://www.ycombinator.com) | Y Combinator | Funding (up to $500,000) |
+| [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator with funding and partner credits |
 | [ZAI Startups](https://startup.z.ai/) | Z.AI | Free API credits for Z.AI models |
 
 ---
@@ -130,7 +131,6 @@ Only official program pages are listed.
 | [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Community benefits |
 | [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Credits and early access |
 | [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Studio API credits, early access |
-| [OpenAI Codex Ambassadors](https://developers.openai.com/community/codex-ambassadors) | OpenAI | Credits and support (applications currently paused) |
 | [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | API credits ($50–$100/month) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome Builder Programs
 
-[![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <a href="https://github.com/doanbactam/awesome-builder-programs/stargazers"><img src="https://img.shields.io/github/stars/doanbactam/awesome-builder-programs?style=flat" alt="Stars" /></a>
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <a href="https://github.com/doanbactam/awesome-builder-programs"><img src="https://img.shields.io/github/stars/doanbactam/awesome-builder-programs?style=flat" alt="Stars" /></a>
 
 A list of programs that provide credits, grants, or tools for people building things.
 


### PR DESCRIPTION
## Summary

- Remove the DigitalOcean Student Credits entry while its former program URL redirects to the provider homepage.
- Update GitHub Secure Open Source Fund to its canonical page and clarify the funding and Azure credit amounts.
- Clarify that Manus credits are a referral reward.
- Link Y Combinator directly to its application page and describe it as a selective accelerator.
- Remove the paused OpenAI Codex Ambassadors program from the active list.
- Add an automated Markdown link-check workflow for pushes and pull requests.
- Ask contributors to re-verify links and benefit descriptions before submitting.

## Context

This is a focused follow-up to [#13](https://github.com/doanbactam/awesome-builder-programs/pull/13). That PR contains overlapping cleanup for the Codex Ambassadors entry and GitHub URL; please coordinate merge order to avoid duplicate changes.

## Validation

- `git diff --check`
- Reviewed the workflow YAML and changed Markdown entries