### PR TITLE
Add structured program data and verification metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Last verified:
 - [ ] The record is in data/programs.json
 - [ ] Official source and application URL are included
 - [ ] Benefit and eligibility are supported by the source
-- [ ] needs_review is used until current availability is manually confirmed
+- [ ] Current benefit, eligibility, and status were manually verified; unverified candidates are not included
 - [ ] Active records include last_verified_at, verification_method, and verification_notes
 - [ ] node scripts/validate-programs.mjs passes
 - [ ] node scripts/generate-readme.mjs was run

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,23 @@
 ## Description
 
-Add a new builder program.
+Describe the program or data change and why it is needed.
 
-## Program
+## Evidence
 
-Name:
-Provider:
-Official link:
+Official source:
+
+Application source (if different):
+
+Status rationale:
+
+Last verified:
 
 ## Checklist
 
-- [ ] Program has an official source
-- [ ] Program is currently active
-- [ ] Entry follows the repository format
-- [ ] Entry is placed in alphabetical order
+- [ ] The record is in data/programs.json
+- [ ] Official source and application URL are included
+- [ ] Benefit and eligibility are supported by the source
+- [ ] needs_review is used until current availability is manually confirmed
+- [ ] Active records include last_verified_at, verification_method, and verification_notes
+- [ ] node scripts/validate-programs.mjs passes
+- [ ] node scripts/generate-readme.mjs was run

--- a/.github/workflows/validate-programs.yml
+++ b/.github/workflows/validate-programs.yml
@@ -1,0 +1,27 @@
+name: Validate program data
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate structured program data
+        run: node scripts/validate-programs.mjs
+
+      - name: Check generated README
+        run: node scripts/generate-readme.mjs --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The canonical records live in data/programs.json. Edit that file rather than edi
 1. Make sure the program has an official page.
 2. Add or update the record in the correct category.
 3. Describe the benefit and eligibility from the official source.
-4. Use needs_review until current availability has been manually confirmed.
+4. Manually verify the current benefit, eligibility, and availability before adding the record. If the evidence is insufficient, leave the candidate out rather than publishing a `needs_review` record.
 5. For active records, add last_verified_at, verification_method, and verification_notes.
 6. Run the validation and README generation commands.
 
@@ -29,15 +29,15 @@ Example record:
         "regions": ["global"],
         "requirements": []
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://example.com/apply",
       "official_url": "https://example.com",
       "source_urls": ["https://example.com"],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
+      "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Explain what was checked."
     }
@@ -52,6 +52,7 @@ Run:
 - Only link to official program pages.
 - No affiliate or referral links.
 - Keep descriptions short and source-backed.
+- Do not publish a candidate until its current benefit, eligibility, and status are supported by an official source.
 - Do not mark a record active without a recent manual verification.
 - Do not add expired programs as active opportunities.
 - Note geographic, school, funding, or age eligibility limits when they apply.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,61 @@
 # Contributing
 
-Thanks for contributing to **Awesome Builder Programs**.
+Thanks for contributing to Awesome Builder Programs.
 
-This repository lists programs that provide **credits, grants, or tools** for students, startups, and open-source builders.
+This repository lists programs that provide credits, grants, or tools for students, startups, and open-source builders.
 
-## How to add a program
+## How to add or update a program
 
-1. Make sure the program has an **official page**
-2. Ensure the program is **active**
-3. Add it in the correct section
-4. Keep entries **alphabetically sorted** by program name
-5. Follow the table format
-6. Confirm the link and benefit description immediately before opening the pull request
+The canonical records live in data/programs.json. Edit that file rather than editing README.md; the README is generated from the structured data.
 
-Example:
+1. Make sure the program has an official page.
+2. Add or update the record in the correct category.
+3. Describe the benefit and eligibility from the official source.
+4. Use needs_review until current availability has been manually confirmed.
+5. For active records, add last_verified_at, verification_method, and verification_notes.
+6. Run the validation and README generation commands.
 
-```markdown
-| [Example Program](https://example.com) | Example | Cloud credits |
-```
+Example record:
+
+    {
+      "slug": "example-program",
+      "name": "Example Program",
+      "provider": "Example",
+      "categories": ["startups"],
+      "program_type": ["startup_program"],
+      "benefits": [{ "type": "credits", "label": "Cloud credits" }],
+      "eligibility": {
+        "stages": ["early_stage"],
+        "regions": ["global"],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://example.com/apply",
+      "official_url": "https://example.com",
+      "source_urls": ["https://example.com"],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "official_page",
+      "verification_notes": "Explain what was checked."
+    }
+
+Run:
+
+    node scripts/validate-programs.mjs
+    node scripts/generate-readme.mjs
 
 ## Rules
 
-- Only link to official program pages
-- No affiliate or referral links
-- Keep descriptions short
-- Do not add expired programs
-- Do not add programs whose applications are paused unless they are clearly marked in a dedicated paused-programs section
-- Note geographic or school eligibility limits when they apply
+- Only link to official program pages.
+- No affiliate or referral links.
+- Keep descriptions short and source-backed.
+- Do not mark a record active without a recent manual verification.
+- Do not add expired programs as active opportunities.
+- Note geographic, school, funding, or age eligibility limits when they apply.
 
 ## Pull requests
 
-Open a Pull Request with a short explanation of the program you added.
+Open a Pull Request with a short explanation of the program or update you added. Include the official source, status rationale, and verification date.

--- a/DATA.md
+++ b/DATA.md
@@ -14,7 +14,7 @@ The machine-readable contract is data/programs.schema.json.
 | program_type | Machine-readable program classification |
 | benefits | One or more benefit objects with type and human-readable label |
 | eligibility | Structured stages, regions, and free-form requirements |
-| status | active, needs_review, paused, expired, or unknown |
+| status | active, needs_review, paused, expired, or unknown (the last two review states are staging-only) |
 | application_state | open, rolling, invite_only, closed, or unknown |
 | deadline | ISO date when a known deadline exists |
 | application_url | Direct application or official program destination |
@@ -29,16 +29,16 @@ The machine-readable contract is data/programs.schema.json.
 ## Status policy
 
 - **active**: the official source confirms current availability and the record was manually verified within 30 days.
-- **needs_review**: the record may still exist, but current availability or terms need confirmation. This status must not be interpreted as discontinued or nonexistent.
+- **needs_review**: a staging/backlog state for a candidate whose current availability or terms need confirmation. It must not be committed to the public `data/programs.json` or interpreted as discontinued/nonexistent.
 - **paused**: the provider explicitly says applications or access are paused.
 - **expired**: the offer or deadline has ended.
-- **unknown**: the record has not yet been classified.
+- **unknown**: the record has not yet been classified; it is also staging-only and must not be published.
 
 An HTTP success response is not sufficient evidence for active. A page that returns 403, 429, or requires a browser challenge must be reviewed manually.
 
-## Migration state
+## Publication gate
 
-The initial structured-data migration imports the curated README entries with status needs_review and no last_verified_at. This is intentional: it avoids presenting an unverified import as fresh availability. Individual records may move to active only after an official-page review with supporting notes.
+Every record committed to `data/programs.json` must have a reviewed benefit, eligibility, and current status supported by an official source. Unverified candidates stay out of the canonical dataset until that evidence is obtained. The validator rejects `needs_review` and `unknown` statuses so an unreviewed record cannot reach the generated README.
 
 Run the checks locally:
 

--- a/DATA.md
+++ b/DATA.md
@@ -29,7 +29,7 @@ The machine-readable contract is data/programs.schema.json.
 ## Status policy
 
 - **active**: the official source confirms current availability and the record was manually verified within 30 days.
-- **needs_review**: the record exists, but current availability or terms need confirmation.
+- **needs_review**: the record may still exist, but current availability or terms need confirmation. This status must not be interpreted as discontinued or nonexistent.
 - **paused**: the provider explicitly says applications or access are paused.
 - **expired**: the offer or deadline has ended.
 - **unknown**: the record has not yet been classified.

--- a/DATA.md
+++ b/DATA.md
@@ -1,0 +1,46 @@
+# Program data
+
+data/programs.json is the canonical source for every program in this repository. The README is generated from that file so that the public list and structured records do not drift.
+
+The machine-readable contract is data/programs.schema.json.
+
+## Record fields
+
+| Field | Meaning |
+|---|---|
+| slug | Stable kebab-case identifier used by future detail pages |
+| name, provider | Display name and provider |
+| categories | One or more list sections |
+| program_type | Machine-readable program classification |
+| benefits | One or more benefit objects with type and human-readable label |
+| eligibility | Structured stages, regions, and free-form requirements |
+| status | active, needs_review, paused, expired, or unknown |
+| application_state | open, rolling, invite_only, closed, or unknown |
+| deadline | ISO date when a known deadline exists |
+| application_url | Direct application or official program destination |
+| official_url | Provider-owned source of truth |
+| source_urls | Evidence URLs; must include official_url |
+| separate_application | Whether a separate application step is known |
+| referral_only | Whether access is referral-only when known |
+| last_verified_at | Date the provider page and current terms were checked |
+| verification_method | How the record was verified |
+| verification_notes | Short evidence and caveats |
+
+## Status policy
+
+- **active**: the official source confirms current availability and the record was manually verified within 30 days.
+- **needs_review**: the record exists, but current availability or terms need confirmation.
+- **paused**: the provider explicitly says applications or access are paused.
+- **expired**: the offer or deadline has ended.
+- **unknown**: the record has not yet been classified.
+
+An HTTP success response is not sufficient evidence for active. A page that returns 403, 429, or requires a browser challenge must be reviewed manually.
+
+## Migration state
+
+The initial structured-data migration imports the curated README entries with status needs_review and no last_verified_at. This is intentional: it avoids presenting an unverified import as fresh availability. Individual records may move to active only after an official-page review with supporting notes.
+
+Run the checks locally:
+
+    node scripts/validate-programs.mjs
+    node scripts/generate-readme.mjs

--- a/README.md
+++ b/README.md
@@ -39,11 +39,7 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [Figma for Education](https://www.figma.com/education/) | Figma | Figma and FigJam are free for students and teachers after education verification | Active | 2026-09-10 |
 | [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | GitHub Student Developer Pack with partner tools, including GitHub Copilot Student | Active | 2026-09-10 |
 | [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | GitLab for Education platform for students, faculty, and educational institutions | Active | 2026-09-10 |
-| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in | Needs review | 2026-09-10 |
-| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Mentored open-source contribution program; stipend and dates vary by annual cycle | Needs review | 2026-09-10 |
-| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Student Pack terms not re-confirmed on the public page snapshot | Needs review | 2026-09-10 |
 | [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 Kiro credits per month free for one year | Active | 2026-09-10 |
-| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Mentorship terms and stipend not re-confirmed on the public page snapshot | Needs review | 2026-09-10 |
 | [Manus Campus for Students](https://manus.im/edu) | Manus | Manus campus access after edu-email verification plus 1,000 credits per invited student | Active | 2026-09-10 |
 | [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | $100 Azure credit plus free monthly amounts for 20+ services for 12 months | Active | 2026-09-10 |
 | [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote open-source fellowship with an educational stipend | Active | 2026-09-10 |
@@ -59,7 +55,6 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
-| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage | Needs review | 2026-09-10 |
 | [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full Capy platform access free while the project remains open source | Active | 2026-09-10 |
 | [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship plus funding and mentorship for an open-source project | Active | 2026-09-10 |
 | [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | Six months of free Claude Max 20x | Active | 2026-09-10 |
@@ -92,23 +87,19 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [Kiro for Startups](https://kiro.dev/startups/) | Kiro (AWS) | Up to one year of Kiro Pro+ credits for early-stage to Series A startups | Active | 2026-09-10 |
 | [Microsoft for Startups](https://www.microsoft.com/startups) | Microsoft | Free Azure credits plus AI tools, expert guidance, and startup resources | Active | 2026-09-10 |
 | [Miro for Startups](https://miro.com/startups/) | Miro | Free Miro credits for early startups; up to 25% discount for scale-ups | Active | 2026-09-10 |
-| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | Startup offer could not be re-confirmed; public URL returned only an embedded form shell | Needs review | 2026-09-10 |
 | [Modal](https://modal.com/startups) | Modal | Thousands of free GPU credits plus technical and go-to-market support | Active | 2026-09-10 |
 | [MongoDB for Startups](https://www.mongodb.com/solutions/startups) | MongoDB | MongoDB Atlas credits, Voyage AI tokens, technical expertise, and support | Active | 2026-09-10 |
 | [Nebius for Startups](https://nebius.com/startups) | Nebius | Nebius startup credits and compute discounts; credit access currently through VC partners | Paused | 2026-09-10 |
 | [Notion for Startups](https://www.notion.com/startups) | Notion | Notion Business with Notion AI free for 3 or 6 months depending on eligibility | Active | 2026-09-10 |
 | [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free NVIDIA Inception membership with partner cloud credits, training, preferred pricing, and resources | Active | 2026-09-10 |
 | [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | Up to €100,000 in free OVHcloud credits plus one-on-one engineering consultation | Active | 2026-09-10 |
-| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up | Needs review | 2026-09-10 |
 | [PostHog for Startups](https://posthog.com/startups) | PostHog | $50,000 in PostHog credits plus $12,000 in partner benefits for 12 months | Active | 2026-09-10 |
 | [Render](https://render.com/startups) | Render | Up to $10,000 in Render migration credits | Active | 2026-09-10 |
 | [Retool for Startups](https://retool.com/startups) | Retool | 100% off Retool Team or Business for one year, up to $60,000 value, then 25% off year two | Active | 2026-09-10 |
-| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Startup offer could not be re-confirmed; official URL rendered only a terminal shell | Needs review | 2026-09-10 |
 | [Stripe Atlas](https://stripe.com/atlas) | Stripe | $2,500 Stripe product credits plus $50,000+ in partner discounts for Atlas companies | Active | 2026-09-10 |
 | [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 in Temporal Cloud credits for funded startups | Active | 2026-09-10 |
 | [Vercel Startups](https://vercel.com/startups) | Vercel | Up to $30,000 Flexible Commitment Amount plus Enterprise-tier access and support | Active | 2026-09-10 |
 | [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator application with funding and partner benefits | Active | 2026-09-10 |
-| [ZAI Startups](https://startup.z.ai/) | Z.AI | Startup API-credit offer could not be re-confirmed; official URL returned an internal error | Needs review | 2026-09-10 |
 
 ---
 
@@ -117,7 +108,6 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
 | [Anthropic Startup Program](https://claude.com/programs/startups) | Anthropic | Claude API credits and priority rate limits for qualifying startups | Active | 2026-09-10 |
-| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms | Needs review | 2026-09-10 |
 | [OpenAI Startup Program](https://openai.com/startups) | OpenAI | OpenAI API credits, rate-limit upgrades, technical support, and startup events for eligible VC portfolios | Active | 2026-09-10 |
 | [Together AI Research Credits Program](https://www.together.ai/research-credits-program-request) | Together AI | Small research grants of a few hundred dollars for eligible student projects | Active | 2026-09-10 |
 | [Together AI Startup Accelerator](https://www.together.ai/startup-accelerator) | Together AI | Up to $15k/$30k/$50k in platform credits by funding tier plus engineering time | Active | 2026-09-10 |
@@ -134,7 +124,6 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Devin Ambassador role with community events, content, and feedback opportunities | Active | 2026-09-10 |
 | [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Exclusive ambassador resources, early product access, direct Kimi-team contact, and recognition | Active | 2026-09-10 |
 | [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Mistral AI ambassador community, content/events participation, product feedback, and community support | Active | 2026-09-10 |
-| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | Ambassador offer could not be re-confirmed; official URL returned no readable public content | Needs review | 2026-09-10 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,23 +35,23 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
-| [Codex for Students](https://chatgpt.com/codex/students) | OpenAI | $100 in Codex credits (US & Canada students only) | Needs review | — |
-| [Figma for Education](https://www.figma.com/education/) | Figma | Free design tools for students | Needs review | — |
-| [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | Developer tools bundle (~$10k value) | Needs review | — |
-| [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | Free GitLab Ultimate for education | Needs review | — |
-| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | 1 year of Google AI Pro (US) or AI Plus (many other countries); claim window through end of 2026 | Needs review | — |
-| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Stipend and mentorship for students contributing to OSS | Needs review | — |
-| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Free IDE licenses | Needs review | — |
-| [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 credits/month free for 1 year (participating universities; SheerID verification) | Needs review | — |
-| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Paid remote OSS mentorship (stipends vary by region) | Needs review | — |
-| [Manus Campus for Students](https://manus.im/edu) | Manus | Campus access; 1,000-credit referral reward per invited student | Needs review | — |
-| [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | Azure credits and dev tools | Needs review | — |
-| [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote fellowship with stipend | Needs review | — |
-| [OpenAI Student Collective](https://openai.com/student-collective/) | OpenAI | Campus Lead role: ChatGPT + Codex credits, event funding, and stipend | Needs review | — |
-| [Outreachy](https://www.outreachy.org/) | Software Freedom Conservancy | Paid remote OSS internship (~$7,000 stipend) | Needs review | — |
-| [v0 for Students](https://v0.app/students) | Vercel | 1 year of free v0 Premium (limited partner universities) | Needs review | — |
-| [YC AI Student Starter Pack](https://deals.ycombinator.com/students) | Y Combinator | Credits and tools (~$25k value; requires attending a YC student event) | Needs review | — |
-| [Zed Student Plan](https://zed.dev/education) | Zed | All Zed Pro features for 12 months | Needs review | — |
+| [Codex for Students](https://chatgpt.com/codex/students) | OpenAI | $100 Codex credits for verified university students in the US and Canada | Active | 2026-09-10 |
+| [Figma for Education](https://www.figma.com/education/) | Figma | Figma and FigJam are free for students and teachers after education verification | Active | 2026-09-10 |
+| [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | GitHub Student Developer Pack with partner tools, including GitHub Copilot Student | Active | 2026-09-10 |
+| [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | GitLab for Education platform for students, faculty, and educational institutions | Active | 2026-09-10 |
+| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in | Needs review | 2026-09-10 |
+| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Mentored open-source contribution program; stipend and dates vary by annual cycle | Needs review | 2026-09-10 |
+| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Student Pack terms not re-confirmed on the public page snapshot | Needs review | 2026-09-10 |
+| [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 Kiro credits per month free for one year | Active | 2026-09-10 |
+| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Mentorship terms and stipend not re-confirmed on the public page snapshot | Needs review | 2026-09-10 |
+| [Manus Campus for Students](https://manus.im/edu) | Manus | Manus campus access after edu-email verification plus 1,000 credits per invited student | Active | 2026-09-10 |
+| [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | $100 Azure credit plus free monthly amounts for 20+ services for 12 months | Active | 2026-09-10 |
+| [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote open-source fellowship with an educational stipend | Active | 2026-09-10 |
+| [OpenAI Student Collective](https://openai.com/student-collective/) | OpenAI | Campus Lead program: ChatGPT subscription, Codex credits, event funding, training, merch, and cash stipend | Paused | 2026-09-10 |
+| [Outreachy](https://www.outreachy.org/) | Software Freedom Conservancy | Paid remote open-source internship; stipend amount varies by cohort and location | Paused | 2026-09-10 |
+| [v0 for Students](https://v0.app/students) | Vercel | One year of free v0 Premium after student verification | Active | 2026-09-10 |
+| [YC AI Student Starter Pack](https://deals.ycombinator.com/students) | Y Combinator | Over $25,000 in credits for AI tools and cloud services | Active | 2026-09-10 |
+| [Zed Student Plan](https://zed.dev/education) | Zed | Zed Pro features plus $10/month AI token credits for one year | Active | 2026-09-10 |
 
 ---
 
@@ -59,16 +59,16 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
-| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | Up to $1,500/mo AI credits (400+ models) for active OSS maintainers | Needs review | — |
-| [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects | Needs review | — |
-| [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship + 3-month program for eligible OSS authors and maintainers | Needs review | — |
-| [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max | Needs review | — |
-| [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) | GitHub | $10,000 project funding, $10,000 Azure credits, Copilot Pro, and a 3-week security program | Needs review | — |
-| [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects | Needs review | — |
-| [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/mo AI credits for OSS maintainers and contributors | Needs review | — |
-| [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | 6 months of ChatGPT Pro with Codex, plus API credits | Needs review | — |
-| [Snyk for Open Source](https://snyk.io/open-source) | Snyk | Full Snyk platform free for qualifying OSS maintainers | Needs review | — |
-| [Upstash for Open Source](https://upstash.com/open-source) | Upstash | $1,000 monthly credit grant | Needs review | — |
+| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage | Needs review | 2026-09-10 |
+| [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full Capy platform access free while the project remains open source | Active | 2026-09-10 |
+| [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship plus funding and mentorship for an open-source project | Active | 2026-09-10 |
+| [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | Six months of free Claude Max 20x | Active | 2026-09-10 |
+| [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) | GitHub | $10,000 per selected open-source project, paid in program tranches | Active | 2026-09-10 |
+| [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Sponsorship rounds for open-source projects selected through Microsoft employee and intern nominations | Active | 2026-09-10 |
+| [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/month in free AI credits for open-source maintainers and contributors | Active | 2026-09-10 |
+| [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | Six months of ChatGPT Pro with Codex plus conditional access to Codex Security | Active | 2026-09-10 |
+| [Snyk for Open Source](https://snyk.io/open-source) | Snyk | Complimentary Snyk security tooling and full licenses for qualifying open-source projects | Active | 2026-09-10 |
+| [Upstash for Open Source](https://upstash.com/open-source) | Upstash | $1,000 monthly credit grant and support (applications currently closed) | Paused | 2026-09-10 |
 
 ---
 
@@ -76,39 +76,39 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
-| [AssemblyAI Startup Program](https://www.assemblyai.com/contact/startup-program) | AssemblyAI | 12 months free credits for voice/speech AI | Needs review | — |
-| [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Cloud credits (up to $100k) | Needs review | — |
-| [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits | Needs review | — |
-| [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro at a discount for early-stage startups | Needs review | — |
-| [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits | Needs review | — |
-| [Databricks Startup Program](https://www.databricks.com/product/startups) | Databricks | Up to $200k in credits across Databricks and Neon | Needs review | — |
-| [Datadog for Startups](https://www.datadoghq.com/partner/datadog-for-startups/) | Datadog | A year of free Datadog Pro | Needs review | — |
-| [Daytona](https://www.daytona.io/startups) | Daytona | Up to $50k in Daytona credits | Needs review | — |
-| [Deepgram for Startups](https://deepgram.com/startup-program) | Deepgram | Up to $100,000 in voice AI credits | Needs review | — |
-| [Devin for Startups](https://devin.ai/startups) | Cognition (Devin) | $65,000 in credits and grants, direct support, free swag | Needs review | — |
-| [DigitalOcean Hatch](https://www.digitalocean.com/startups) | DigitalOcean | Up to $100,000 in cloud credits | Needs review | — |
-| [Google Cloud AI Startup Program](https://cloud.google.com/startup/ai) | Google | AI startup credits (up to $350k) | Needs review | — |
-| [Google Cloud Startup Program](https://cloud.google.com/startup) | Google | Cloud credits and support | Needs review | — |
-| [Kiro for Startups](https://kiro.dev/startups/) | Kiro (AWS) | Up to 1 year of Kiro Pro+ credits (early stage to Series A; not stackable with active AWS Activate) | Needs review | — |
-| [Microsoft for Startups](https://www.microsoft.com/startups) | Microsoft | Azure credits | Needs review | — |
-| [Miro for Startups](https://miro.com/startups/) | Miro | $500–$1,000 in credits | Needs review | — |
-| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | First year of Mixpanel free | Needs review | — |
-| [Modal](https://modal.com/startups) | Modal | Free credits and technical support | Needs review | — |
-| [MongoDB for Startups](https://www.mongodb.com/solutions/startups) | MongoDB | Atlas credits and technical advisors | Needs review | — |
-| [Nebius for Startups](https://nebius.com/startups) | Nebius | $5,000 AI credits + discounts on GPU compute | Needs review | — |
-| [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) | Needs review | — |
-| [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free program: partner cloud credits, training, preferred GPU/software pricing | Needs review | — |
-| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000 for Start level; up to €100,000 for Scale level, plus technical support | Needs review | — |
-| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits | Needs review | — |
-| [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) | Needs review | — |
-| [Render](https://render.com/startups) | Render | Up to $100,000 in credits | Needs review | — |
-| [Retool for Startups](https://retool.com/startups) | Retool | Free Retool access for early-stage startups | Needs review | — |
-| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Up to $5,000 in credits and priority support | Needs review | — |
-| [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation and partner perks | Needs review | — |
-| [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 Temporal Cloud credits (funded startups, $30M or less raised) | Needs review | — |
-| [Vercel Startups](https://vercel.com/startups) | Vercel | Hosting credits | Needs review | — |
-| [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator with funding and partner credits | Needs review | — |
-| [ZAI Startups](https://startup.z.ai/) | Z.AI | Free API credits for Z.AI models | Needs review | — |
+| [AssemblyAI Startup Program](https://www.assemblyai.com/contact/startup-program) | AssemblyAI | 12 months of recurring free credits plus discounted startup pricing | Active | 2026-09-10 |
+| [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Up to $200,000 in AWS Activate credits, with $200,000+ AI credits available by invitation | Active | 2026-09-10 |
+| [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits plus up to 24 months free and Starter Support | Active | 2026-09-10 |
+| [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro features at a startup discount for up to one year after launch | Active | 2026-09-10 |
+| [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits for one year | Active | 2026-09-10 |
+| [Databricks Startup Program](https://www.databricks.com/product/startups) | Databricks | Up to $200,000 in credits for Databricks and Neon | Active | 2026-09-10 |
+| [Datadog for Startups](https://www.datadoghq.com/partner/datadog-for-startups/) | Datadog | Up to one year of free Datadog platform access, up to $100,000 in credits | Active | 2026-09-10 |
+| [Daytona](https://www.daytona.io/startups) | Daytona | $10,000 immediately and up to $100,000 in Daytona credits | Active | 2026-09-10 |
+| [Deepgram for Startups](https://deepgram.com/startup-program) | Deepgram | Up to $100,000 in Deepgram credits over 12 months | Active | 2026-09-10 |
+| [Devin for Startups](https://devin.ai/startups) | Cognition (Devin) | $15,000 Devin credits plus up to $50,000 in matching grants | Active | 2026-09-10 |
+| [DigitalOcean Hatch](https://www.digitalocean.com/startups) | DigitalOcean | DigitalOcean startup credits and invited GPU credit packages | Active | 2026-09-10 |
+| [Google Cloud AI Startup Program](https://cloud.google.com/startup/ai) | Google | Up to $350,000 in Google Cloud credits for AI-first startups over two years | Active | 2026-09-10 |
+| [Google Cloud Startup Program](https://cloud.google.com/startup) | Google | Up to $200,000 in Google Cloud credits, or up to $350,000 for AI-first startups | Active | 2026-09-10 |
+| [Kiro for Startups](https://kiro.dev/startups/) | Kiro (AWS) | Up to one year of Kiro Pro+ credits for early-stage to Series A startups | Active | 2026-09-10 |
+| [Microsoft for Startups](https://www.microsoft.com/startups) | Microsoft | Free Azure credits plus AI tools, expert guidance, and startup resources | Active | 2026-09-10 |
+| [Miro for Startups](https://miro.com/startups/) | Miro | Free Miro credits for early startups; up to 25% discount for scale-ups | Active | 2026-09-10 |
+| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | Startup offer could not be re-confirmed; public URL returned only an embedded form shell | Needs review | 2026-09-10 |
+| [Modal](https://modal.com/startups) | Modal | Thousands of free GPU credits plus technical and go-to-market support | Active | 2026-09-10 |
+| [MongoDB for Startups](https://www.mongodb.com/solutions/startups) | MongoDB | MongoDB Atlas credits, Voyage AI tokens, technical expertise, and support | Active | 2026-09-10 |
+| [Nebius for Startups](https://nebius.com/startups) | Nebius | Nebius startup credits and compute discounts; credit access currently through VC partners | Paused | 2026-09-10 |
+| [Notion for Startups](https://www.notion.com/startups) | Notion | Notion Business with Notion AI free for 3 or 6 months depending on eligibility | Active | 2026-09-10 |
+| [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free NVIDIA Inception membership with partner cloud credits, training, preferred pricing, and resources | Active | 2026-09-10 |
+| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | Up to €100,000 in free OVHcloud credits plus one-on-one engineering consultation | Active | 2026-09-10 |
+| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up | Needs review | 2026-09-10 |
+| [PostHog for Startups](https://posthog.com/startups) | PostHog | $50,000 in PostHog credits plus $12,000 in partner benefits for 12 months | Active | 2026-09-10 |
+| [Render](https://render.com/startups) | Render | Up to $10,000 in Render migration credits | Active | 2026-09-10 |
+| [Retool for Startups](https://retool.com/startups) | Retool | 100% off Retool Team or Business for one year, up to $60,000 value, then 25% off year two | Active | 2026-09-10 |
+| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Startup offer could not be re-confirmed; official URL rendered only a terminal shell | Needs review | 2026-09-10 |
+| [Stripe Atlas](https://stripe.com/atlas) | Stripe | $2,500 Stripe product credits plus $50,000+ in partner discounts for Atlas companies | Active | 2026-09-10 |
+| [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 in Temporal Cloud credits for funded startups | Active | 2026-09-10 |
+| [Vercel Startups](https://vercel.com/startups) | Vercel | Up to $30,000 Flexible Commitment Amount plus Enterprise-tier access and support | Active | 2026-09-10 |
+| [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator application with funding and partner benefits | Active | 2026-09-10 |
+| [ZAI Startups](https://startup.z.ai/) | Z.AI | Startup API-credit offer could not be re-confirmed; official URL returned an internal error | Needs review | 2026-09-10 |
 
 ---
 
@@ -116,11 +116,11 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
-| [Anthropic Startup Program](https://claude.com/programs/startups) | Anthropic | Claude API credits and priority rate limits | Needs review | — |
-| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | AI infrastructure support | Needs review | — |
-| [OpenAI Startup Program](https://openai.com/startups) | OpenAI | API credits | Needs review | — |
-| [Together AI Research Credits Program](https://www.together.ai/research-credits-program-request) | Together AI | Research credits for AI projects | Needs review | — |
-| [Together AI Startup Accelerator](https://www.together.ai/startup-accelerator) | Together AI | Up to $50k in credits (funding-gated) | Needs review | — |
+| [Anthropic Startup Program](https://claude.com/programs/startups) | Anthropic | Claude API credits and priority rate limits for qualifying startups | Active | 2026-09-10 |
+| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms | Needs review | 2026-09-10 |
+| [OpenAI Startup Program](https://openai.com/startups) | OpenAI | OpenAI API credits, rate-limit upgrades, technical support, and startup events for eligible VC portfolios | Active | 2026-09-10 |
+| [Together AI Research Credits Program](https://www.together.ai/research-credits-program-request) | Together AI | Small research grants of a few hundred dollars for eligible student projects | Active | 2026-09-10 |
+| [Together AI Startup Accelerator](https://www.together.ai/startup-accelerator) | Together AI | Up to $15k/$30k/$50k in platform credits by funding tier plus engineering time | Active | 2026-09-10 |
 
 ---
 
@@ -128,13 +128,13 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 | Program | Provider | Benefit | Status | Verified |
 |---|---|---|---|---|
-| [Claude Campus Ambassadors](https://claude.com/programs/campus) | Anthropic | Campus club lead; USD 3,600 stipend (18+) | Needs review | — |
-| [Claude Community Ambassadors](https://claude.com/community/ambassadors) | Anthropic | API credits, event support | Needs review | — |
-| [Cursor Campus Leads](https://cursor.com/campus-leads) | Cursor | 6 months Cursor Ultra and event funding (applications reopen January) | Needs review | — |
-| [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Community benefits | Needs review | — |
-| [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Credits and early access | Needs review | — |
-| [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Studio API credits, early access | Needs review | — |
-| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | API credits ($50–$100/month) | Needs review | — |
+| [Claude Campus Ambassadors](https://claude.com/programs/campus) | Anthropic | USD 3,600 cash stipend plus campus event support, resources, and API credits | Active | 2026-09-10 |
+| [Claude Community Ambassadors](https://claude.com/community/ambassadors) | Anthropic | Event sponsorship, API credits, swag, resources, and product feedback access | Active | 2026-09-10 |
+| [Cursor Campus Leads](https://cursor.com/campus-leads) | Cursor | Campus Lead benefits include six months of Cursor Ultra, event funding, travel support, and swag | Paused | 2026-09-10 |
+| [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Devin Ambassador role with community events, content, and feedback opportunities | Active | 2026-09-10 |
+| [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Exclusive ambassador resources, early product access, direct Kimi-team contact, and recognition | Active | 2026-09-10 |
+| [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Mistral AI ambassador community, content/events participation, product feedback, and community support | Active | 2026-09-10 |
+| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | Ambassador offer could not be re-confirmed; official URL returned no readable public content | Needs review | 2026-09-10 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 * [Startups](#startups)
 * [AI and Developer Credits](#ai-and-developer-credits)
 * [Ambassadors](#ambassadors)
-* [Needs review](#needs-review)
 * [Data quality](#data-quality)
 * [Contributing](#contributing)
 
@@ -40,7 +39,11 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [Figma for Education](https://www.figma.com/education/) | Figma | Figma and FigJam are free for students and teachers after education verification | Active | 2026-09-10 |
 | [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | GitHub Student Developer Pack with partner tools, including GitHub Copilot Student | Active | 2026-09-10 |
 | [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | GitLab for Education platform for students, faculty, and educational institutions | Active | 2026-09-10 |
+| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | Discounted Google AI Pro while enrolled; eligible regions may receive a 12-month Google AI Plus student trial | Active | 2026-09-10 |
+| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | PPP-adjusted stipend for an 8–22 week mentored open-source project | Paused | 2026-09-10 |
+| [JetBrains Student Pack](https://www.jetbrains.com/shop/eform/students) | JetBrains | Free JetBrains professional IDEs for verified students | Active | 2026-09-10 |
 | [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 Kiro credits per month free for one year | Active | 2026-09-10 |
+| [LFX Mentorship](https://mentorship.lfx.dev/) | Linux Foundation | Open-source mentorship with a stipend; amount varies by program and region | Active | 2026-09-10 |
 | [Manus Campus for Students](https://manus.im/edu) | Manus | Manus campus access after edu-email verification plus 1,000 credits per invited student | Active | 2026-09-10 |
 | [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | $100 Azure credit plus free monthly amounts for 20+ services for 12 months | Active | 2026-09-10 |
 | [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote open-source fellowship with an educational stipend | Active | 2026-09-10 |
@@ -88,6 +91,7 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [Kiro for Startups](https://kiro.dev/startups/) | Kiro (AWS) | Up to one year of Kiro Pro+ credits for early-stage to Series A startups | Active | 2026-09-10 |
 | [Microsoft for Startups](https://www.microsoft.com/startups) | Microsoft | Free Azure credits plus AI tools, expert guidance, and startup resources | Active | 2026-09-10 |
 | [Miro for Startups](https://miro.com/startups/) | Miro | Free Miro credits for early startups; up to 25% discount for scale-ups | Active | 2026-09-10 |
+| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | Mixpanel Startup Plan free for 12 months, up to 1B events per year | Active | 2026-09-10 |
 | [Modal](https://modal.com/startups) | Modal | Thousands of free GPU credits plus technical and go-to-market support | Active | 2026-09-10 |
 | [MongoDB for Startups](https://www.mongodb.com/solutions/startups) | MongoDB | MongoDB Atlas credits, Voyage AI tokens, technical expertise, and support | Active | 2026-09-10 |
 | [Nebius for Startups](https://nebius.com/startups) | Nebius | Nebius startup credits and compute discounts; credit access currently through VC partners | Paused | 2026-09-10 |
@@ -97,10 +101,12 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [PostHog for Startups](https://posthog.com/startups) | PostHog | $50,000 in PostHog credits plus $12,000 in partner benefits for 12 months | Active | 2026-09-10 |
 | [Render](https://render.com/startups) | Render | Up to $10,000 in Render migration credits | Active | 2026-09-10 |
 | [Retool for Startups](https://retool.com/startups) | Retool | 100% off Retool Team or Business for one year, up to $60,000 value, then 25% off year two | Active | 2026-09-10 |
+| [Sentry for Startups](https://sentry.io/for/startups/apply/) | Sentry | Sentry credits<br />Priority support<br />Sentry swag | Active | 2026-09-10 |
 | [Stripe Atlas](https://stripe.com/atlas) | Stripe | $2,500 Stripe product credits plus $50,000+ in partner discounts for Atlas companies | Active | 2026-09-10 |
 | [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 in Temporal Cloud credits for funded startups | Active | 2026-09-10 |
 | [Vercel Startups](https://vercel.com/startups) | Vercel | Up to $30,000 Flexible Commitment Amount plus Enterprise-tier access and support | Active | 2026-09-10 |
 | [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator application with funding and partner benefits | Active | 2026-09-10 |
+| [ZAI Startups](https://startup.z.ai/#apply) | Z.AI | Free Z.ai API credits up to 1B tokens, plus priority support, early API access, and startup community access | Active | 2026-09-10 |
 
 ---
 
@@ -125,34 +131,15 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 | [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Devin Ambassador role with community events, content, and feedback opportunities | Active | 2026-09-10 |
 | [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Exclusive ambassador resources, early product access, direct Kimi-team contact, and recognition | Active | 2026-09-10 |
 | [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Mistral AI ambassador community, content/events participation, product feedback, and community support | Active | 2026-09-10 |
-
----
-
-## Needs review
-
-These records are retained because the program may still exist, but its current offer or availability could not be confirmed from a readable public source. They are not presented as active opportunities until verified.
-
-| Program | Provider | Benefit | Why it needs review | Checked |
-|---|---|---|---|---|
-| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage | Official OSS URL checked 2026-09-10 and redirected to the general Atlas Cloud homepage; the claimed OSS credit amount and application flow could not be independently verified. | 2026-09-10 |
-| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in | Official link checked 2026-09-10 but redirects to Google Accounts sign-in; public benefit, eligibility, and current claim window could not be independently verified. | 2026-09-10 |
-| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Mentored open-source contribution program; stipend and dates vary by annual cycle | Official homepage checked 2026-09-10: program and how-to-apply materials are present, but no current 2026 application dates or stipend terms were exposed in the public page snapshot. | 2026-09-10 |
-| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms | Official URL checked 2026-09-10 but resolves to a public Hugging Face profile named startupsdao with no startup-program benefits or application terms; requires manual review. | 2026-09-10 |
-| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Student Pack terms not re-confirmed on the public page snapshot | Official URL checked 2026-09-10 but returned no readable program terms; current student-pack availability requires manual review. | 2026-09-10 |
-| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Mentorship terms and stipend not re-confirmed on the public page snapshot | Official URL checked 2026-09-10 but no readable public content was returned; current mentorship rounds and stipends require manual review. | 2026-09-10 |
-| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | Startup offer could not be re-confirmed; public URL returned only an embedded form shell | Official URL checked 2026-09-10 but the page exposed only an iframe shell with no readable offer terms; current Mixpanel startup benefit requires manual review. | 2026-09-10 |
-| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up | Official PlanetScale page checked 2026-09-10: startup landing page is live, but no startup credit amount or dedicated offer was publicly stated; only free sign-up and paid pricing were visible. | 2026-09-10 |
-| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | Ambassador offer could not be re-confirmed; official URL returned no readable public content | Official URL checked 2026-09-10 but returned no readable public content; current Qwen ambassador benefits and application status require manual review. | 2026-09-10 |
-| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Startup offer could not be re-confirmed; official URL rendered only a terminal shell | Official URL checked 2026-09-10 but rendered only a terminal shell with no readable program terms; current Sentry offer requires manual review. | 2026-09-10 |
-| [ZAI Startups](https://startup.z.ai/) | Z.AI | Startup API-credit offer could not be re-confirmed; official URL returned an internal error | Official URL checked 2026-09-10 but returned an internal error with no readable program terms; current Z.AI startup offer requires manual review. | 2026-09-10 |
+| [Qwen Ambassadors](https://alidocs.dingtalk.com/notable/share/form/v01J9LnW6jR1E0aalvD_dv19yqvsgs3oebp3pcjys_1qX0QQ0?source=link) | Alibaba Qwen | Qwen API credits of $50–$100 per month for active ambassadors<br />Early access to Qwen models, private team chats, community badge, merchandise, and event support | Active | 2026-09-10 |
 
 ---
 
 ## Data quality
 
 - **Active** means an official source confirms availability and the record was verified within the last 30 days.
-- **Needs review** means the record may still exist, but its current availability or terms could not be confirmed; it is retained separately and is not an active recommendation.
 - **Paused** and **Expired** records are retained for provenance but are not active opportunities.
+- Unverified records (`needs_review` or `unknown`) are staging-only and are excluded from data/programs.json and this README.
 - A successful link check does not by itself prove that a program is accepting applications.
 
 See [DATA.md](DATA.md) for the schema and verification policy.
@@ -166,6 +153,7 @@ Contributions are welcome! Edit [data/programs.json](data/programs.json) rather 
 Before opening a pull request:
 
 - Link to the official program page
+- Verify the current benefit, eligibility, and status before adding the record; leave it out if the evidence is insufficient
 - Make sure the current status and benefit are supported by the source
 - Note geographic, school, funding, or age eligibility limits when they apply
 - Add last_verified_at and verification notes for active records

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <a href="https://github.com/doanbactam/awesome-builder-programs"><img src="https://img.shields.io/github/stars/doanbactam/awesome-builder-programs?style=flat" alt="Stars" /></a>
 
-A list of programs that provide credits, grants, or tools for people building things.
+A curated list of programs that provide credits, grants, or tools for people building things.
 
 Includes programs for:
 
@@ -15,145 +15,155 @@ Only official program pages are listed.
 
 Program availability and benefits can change. Verify the provider page before applying.
 
+The canonical structured dataset is [data/programs.json](data/programs.json).
+
 ---
 
 ## Contents
 
 * [Students](#students)
-* [Open source](#open-source)
+* [Open Source](#open-source)
 * [Startups](#startups)
-* [AI and developer credits](#ai-and-developer-credits)
+* [AI and Developer Credits](#ai-and-developer-credits)
 * [Ambassadors](#ambassadors)
+* [Data quality](#data-quality)
 * [Contributing](#contributing)
 
 ---
 
 ## Students
 
-| Program | Provider | Benefit |
-|---|---|---|
-| [Codex for Students](https://chatgpt.com/codex/students) | OpenAI | $100 in Codex credits (US & Canada students only) |
-| [Figma for Education](https://www.figma.com/education/) | Figma | Free design tools for students |
-| [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | Developer tools bundle (~$10k value) |
-| [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | Free GitLab Ultimate for education |
-| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | 1 year of Google AI Pro (US) or AI Plus (many other countries); claim window through end of 2026 |
-| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Stipend and mentorship for students contributing to OSS |
-| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Free IDE licenses |
-| [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 credits/month free for 1 year (participating universities; SheerID verification) |
-| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Paid remote OSS mentorship (stipends vary by region) |
-| [Manus Campus for Students](https://manus.im/edu) | Manus | Campus access; 1,000-credit referral reward per invited student |
-| [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | Azure credits and dev tools |
-| [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote fellowship with stipend |
-| [OpenAI Student Collective](https://openai.com/student-collective/) | OpenAI | Campus Lead role: ChatGPT + Codex credits, event funding, and stipend |
-| [Outreachy](https://www.outreachy.org/) | Software Freedom Conservancy | Paid remote OSS internship (~$7,000 stipend) |
-| [v0 for Students](https://v0.app/students) | Vercel | 1 year of free v0 Premium (limited partner universities) |
-| [YC AI Student Starter Pack](https://deals.ycombinator.com/students) | Y Combinator | Credits and tools (~$25k value; requires attending a YC student event) |
-| [Zed Student Plan](https://zed.dev/education) | Zed | All Zed Pro features for 12 months |
+| Program | Provider | Benefit | Status | Verified |
+|---|---|---|---|---|
+| [Codex for Students](https://chatgpt.com/codex/students) | OpenAI | $100 in Codex credits (US & Canada students only) | Needs review | — |
+| [Figma for Education](https://www.figma.com/education/) | Figma | Free design tools for students | Needs review | — |
+| [GitHub Student Developer Pack](https://education.github.com/pack) | GitHub | Developer tools bundle (~$10k value) | Needs review | — |
+| [GitLab for Education](https://about.gitlab.com/solutions/education/) | GitLab | Free GitLab Ultimate for education | Needs review | — |
+| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | 1 year of Google AI Pro (US) or AI Plus (many other countries); claim window through end of 2026 | Needs review | — |
+| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Stipend and mentorship for students contributing to OSS | Needs review | — |
+| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Free IDE licenses | Needs review | — |
+| [Kiro for Students](https://kiro.dev/students/) | Kiro (AWS) | 1,000 credits/month free for 1 year (participating universities; SheerID verification) | Needs review | — |
+| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Paid remote OSS mentorship (stipends vary by region) | Needs review | — |
+| [Manus Campus for Students](https://manus.im/edu) | Manus | Campus access; 1,000-credit referral reward per invited student | Needs review | — |
+| [Microsoft Azure for Students](https://azure.microsoft.com/en-us/free/students/) | Microsoft | Azure credits and dev tools | Needs review | — |
+| [MLH Fellowship](https://fellowship.mlh.com/) | Major League Hacking | 12-week remote fellowship with stipend | Needs review | — |
+| [OpenAI Student Collective](https://openai.com/student-collective/) | OpenAI | Campus Lead role: ChatGPT + Codex credits, event funding, and stipend | Needs review | — |
+| [Outreachy](https://www.outreachy.org/) | Software Freedom Conservancy | Paid remote OSS internship (~$7,000 stipend) | Needs review | — |
+| [v0 for Students](https://v0.app/students) | Vercel | 1 year of free v0 Premium (limited partner universities) | Needs review | — |
+| [YC AI Student Starter Pack](https://deals.ycombinator.com/students) | Y Combinator | Credits and tools (~$25k value; requires attending a YC student event) | Needs review | — |
+| [Zed Student Plan](https://zed.dev/education) | Zed | All Zed Pro features for 12 months | Needs review | — |
 
 ---
 
 ## Open Source
 
-| Program | Provider | Benefit |
-|---|---|---|
-| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | Up to $1,500/mo AI credits (400+ models) for active OSS maintainers |
-| [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects |
-| [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship + 3-month program for eligible OSS authors and maintainers |
-| [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max |
-| [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) | GitHub | $10,000 project funding, $10,000 Azure credits, Copilot Pro, and a 3-week security program |
-| [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects |
-| [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/mo AI credits for OSS maintainers and contributors |
-| [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | 6 months of ChatGPT Pro with Codex, plus API credits |
-| [Snyk for Open Source](https://snyk.io/open-source) | Snyk | Full Snyk platform free for qualifying OSS maintainers |
-| [Upstash for Open Source](https://upstash.com/open-source) | Upstash | $1,000 monthly credit grant |
+| Program | Provider | Benefit | Status | Verified |
+|---|---|---|---|---|
+| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | Up to $1,500/mo AI credits (400+ models) for active OSS maintainers | Needs review | — |
+| [Capy AI OSS](https://capy.ai/open-source) | Capy AI | Full platform access for open-source projects | Needs review | — |
+| [Catalyst](https://opencoreventures.com/catalyst/) | Open Core Ventures | $10,000 sponsorship + 3-month program for eligible OSS authors and maintainers | Needs review | — |
+| [Claude for Open Source](https://claude.com/contact-sales/claude-for-oss) | Anthropic | 6 months of Claude Max | Needs review | — |
+| [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) | GitHub | $10,000 project funding, $10,000 Azure credits, Copilot Pro, and a 3-week security program | Needs review | — |
+| [Microsoft FOSS Fund](https://github.com/microsoft/foss-fund) | Microsoft | Up to $12,500 USD for selected projects | Needs review | — |
+| [Ona for Open Source](https://ona.com/stories/ona-for-open-source) | Ona | Up to $200/mo AI credits for OSS maintainers and contributors | Needs review | — |
+| [OpenAI Codex for Open Source](https://developers.openai.com/community/codex-for-oss) | OpenAI | 6 months of ChatGPT Pro with Codex, plus API credits | Needs review | — |
+| [Snyk for Open Source](https://snyk.io/open-source) | Snyk | Full Snyk platform free for qualifying OSS maintainers | Needs review | — |
+| [Upstash for Open Source](https://upstash.com/open-source) | Upstash | $1,000 monthly credit grant | Needs review | — |
 
 ---
 
 ## Startups
 
-| Program | Provider | Benefit |
-|---|---|---|
-| [AssemblyAI Startup Program](https://www.assemblyai.com/contact/startup-program) | AssemblyAI | 12 months free credits for voice/speech AI |
-| [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Cloud credits (up to $100k) |
-| [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits |
-| [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro at a discount for early-stage startups |
-| [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits |
-| [Databricks Startup Program](https://www.databricks.com/product/startups) | Databricks | Up to $200k in credits across Databricks and Neon |
-| [Datadog for Startups](https://www.datadoghq.com/partner/datadog-for-startups/) | Datadog | A year of free Datadog Pro |
-| [Daytona](https://www.daytona.io/startups) | Daytona | Up to $50k in Daytona credits |
-| [Deepgram for Startups](https://deepgram.com/startup-program) | Deepgram | Up to $100,000 in voice AI credits |
-| [Devin for Startups](https://devin.ai/startups) | Cognition (Devin) | $65,000 in credits and grants, direct support, free swag |
-| [DigitalOcean Hatch](https://www.digitalocean.com/startups) | DigitalOcean | Up to $100,000 in cloud credits |
-| [Google Cloud AI Startup Program](https://cloud.google.com/startup/ai) | Google | AI startup credits (up to $350k) |
-| [Google Cloud Startup Program](https://cloud.google.com/startup) | Google | Cloud credits and support |
-| [Kiro for Startups](https://kiro.dev/startups/) | Kiro (AWS) | Up to 1 year of Kiro Pro+ credits (early stage to Series A; not stackable with active AWS Activate) |
-| [Microsoft for Startups](https://www.microsoft.com/startups) | Microsoft | Azure credits |
-| [Miro for Startups](https://miro.com/startups/) | Miro | $500–$1,000 in credits |
-| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | First year of Mixpanel free |
-| [Modal](https://modal.com/startups) | Modal | Free credits and technical support |
-| [MongoDB for Startups](https://www.mongodb.com/solutions/startups) | MongoDB | Atlas credits and technical advisors |
-| [Nebius for Startups](https://nebius.com/startups) | Nebius | $5,000 AI credits + discounts on GPU compute |
-| [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) |
-| [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free program: partner cloud credits, training, preferred GPU/software pricing |
-| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000 for Start level; up to €100,000 for Scale level, plus technical support |
-| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits |
-| [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) |
-| [Render](https://render.com/startups) | Render | Up to $100,000 in credits |
-| [Retool for Startups](https://retool.com/startups) | Retool | Free Retool access for early-stage startups |
-| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Up to $5,000 in credits and priority support |
-| [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation and partner perks |
-| [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 Temporal Cloud credits (funded startups, $30M or less raised) |
-| [Vercel Startups](https://vercel.com/startups) | Vercel | Hosting credits |
-| [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator with funding and partner credits |
-| [ZAI Startups](https://startup.z.ai/) | Z.AI | Free API credits for Z.AI models |
+| Program | Provider | Benefit | Status | Verified |
+|---|---|---|---|---|
+| [AssemblyAI Startup Program](https://www.assemblyai.com/contact/startup-program) | AssemblyAI | 12 months free credits for voice/speech AI | Needs review | — |
+| [AWS Activate](https://aws.amazon.com/startups/credits) | AWS | Cloud credits (up to $100k) | Needs review | — |
+| [CircleCI for Startups](https://circleci.com/startup-program/) | CircleCI | Up to $20,000 in compute credits | Needs review | — |
+| [Clerk for Startups](https://clerk.com/startups) | Clerk | Clerk Pro at a discount for early-stage startups | Needs review | — |
+| [Cloudflare for Startups](https://www.cloudflare.com/forstartups/) | Cloudflare | Up to $350,000 in Cloudflare credits | Needs review | — |
+| [Databricks Startup Program](https://www.databricks.com/product/startups) | Databricks | Up to $200k in credits across Databricks and Neon | Needs review | — |
+| [Datadog for Startups](https://www.datadoghq.com/partner/datadog-for-startups/) | Datadog | A year of free Datadog Pro | Needs review | — |
+| [Daytona](https://www.daytona.io/startups) | Daytona | Up to $50k in Daytona credits | Needs review | — |
+| [Deepgram for Startups](https://deepgram.com/startup-program) | Deepgram | Up to $100,000 in voice AI credits | Needs review | — |
+| [Devin for Startups](https://devin.ai/startups) | Cognition (Devin) | $65,000 in credits and grants, direct support, free swag | Needs review | — |
+| [DigitalOcean Hatch](https://www.digitalocean.com/startups) | DigitalOcean | Up to $100,000 in cloud credits | Needs review | — |
+| [Google Cloud AI Startup Program](https://cloud.google.com/startup/ai) | Google | AI startup credits (up to $350k) | Needs review | — |
+| [Google Cloud Startup Program](https://cloud.google.com/startup) | Google | Cloud credits and support | Needs review | — |
+| [Kiro for Startups](https://kiro.dev/startups/) | Kiro (AWS) | Up to 1 year of Kiro Pro+ credits (early stage to Series A; not stackable with active AWS Activate) | Needs review | — |
+| [Microsoft for Startups](https://www.microsoft.com/startups) | Microsoft | Azure credits | Needs review | — |
+| [Miro for Startups](https://miro.com/startups/) | Miro | $500–$1,000 in credits | Needs review | — |
+| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | First year of Mixpanel free | Needs review | — |
+| [Modal](https://modal.com/startups) | Modal | Free credits and technical support | Needs review | — |
+| [MongoDB for Startups](https://www.mongodb.com/solutions/startups) | MongoDB | Atlas credits and technical advisors | Needs review | — |
+| [Nebius for Startups](https://nebius.com/startups) | Nebius | $5,000 AI credits + discounts on GPU compute | Needs review | — |
+| [Notion for Startups](https://www.notion.com/startups) | Notion | Business plan free for up to 6 months (incl. Notion AI) | Needs review | — |
+| [NVIDIA Inception](https://www.nvidia.com/en-us/startups/) | NVIDIA | Free program: partner cloud credits, training, preferred GPU/software pricing | Needs review | — |
+| [OVHcloud Startup Program](https://startup.ovhcloud.com/) | OVHcloud | €10,000 for Start level; up to €100,000 for Scale level, plus technical support | Needs review | — |
+| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Serverless MySQL database credits | Needs review | — |
+| [PostHog for Startups](https://posthog.com/startups) | PostHog | Product analytics credits (up to ~$50k) | Needs review | — |
+| [Render](https://render.com/startups) | Render | Up to $100,000 in credits | Needs review | — |
+| [Retool for Startups](https://retool.com/startups) | Retool | Free Retool access for early-stage startups | Needs review | — |
+| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Up to $5,000 in credits and priority support | Needs review | — |
+| [Stripe Atlas](https://stripe.com/atlas) | Stripe | Company formation and partner perks | Needs review | — |
+| [Temporal Cloud for Startups](https://temporal.io/startup) | Temporal | $6,000 Temporal Cloud credits (funded startups, $30M or less raised) | Needs review | — |
+| [Vercel Startups](https://vercel.com/startups) | Vercel | Hosting credits | Needs review | — |
+| [Y Combinator](https://www.ycombinator.com/apply) | Y Combinator | Selective accelerator with funding and partner credits | Needs review | — |
+| [ZAI Startups](https://startup.z.ai/) | Z.AI | Free API credits for Z.AI models | Needs review | — |
 
 ---
 
 ## AI and Developer Credits
 
-| Program | Provider | Benefit |
-|---|---|---|
-| [Anthropic Startup Program](https://claude.com/programs/startups) | Anthropic | Claude API credits and priority rate limits |
-| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | AI infrastructure support |
-| [OpenAI Startup Program](https://openai.com/startups) | OpenAI | API credits |
-| [Together AI Research Credits Program](https://www.together.ai/research-credits-program-request) | Together AI | Research credits for AI projects |
-| [Together AI Startup Accelerator](https://www.together.ai/startup-accelerator) | Together AI | Up to $50k in credits (funding-gated) |
+| Program | Provider | Benefit | Status | Verified |
+|---|---|---|---|---|
+| [Anthropic Startup Program](https://claude.com/programs/startups) | Anthropic | Claude API credits and priority rate limits | Needs review | — |
+| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | AI infrastructure support | Needs review | — |
+| [OpenAI Startup Program](https://openai.com/startups) | OpenAI | API credits | Needs review | — |
+| [Together AI Research Credits Program](https://www.together.ai/research-credits-program-request) | Together AI | Research credits for AI projects | Needs review | — |
+| [Together AI Startup Accelerator](https://www.together.ai/startup-accelerator) | Together AI | Up to $50k in credits (funding-gated) | Needs review | — |
 
 ---
 
 ## Ambassadors
 
-| Program | Provider | Benefit |
-|---|---|---|
-| [Claude Campus Ambassadors](https://claude.com/programs/campus) | Anthropic | Campus club lead; USD 3,600 stipend (18+) |
-| [Claude Community Ambassadors](https://claude.com/community/ambassadors) | Anthropic | API credits, event support |
-| [Cursor Campus Leads](https://cursor.com/campus-leads) | Cursor | 6 months Cursor Ultra and event funding (applications reopen January) |
-| [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Community benefits |
-| [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Credits and early access |
-| [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Studio API credits, early access |
-| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | API credits ($50–$100/month) |
+| Program | Provider | Benefit | Status | Verified |
+|---|---|---|---|---|
+| [Claude Campus Ambassadors](https://claude.com/programs/campus) | Anthropic | Campus club lead; USD 3,600 stipend (18+) | Needs review | — |
+| [Claude Community Ambassadors](https://claude.com/community/ambassadors) | Anthropic | API credits, event support | Needs review | — |
+| [Cursor Campus Leads](https://cursor.com/campus-leads) | Cursor | 6 months Cursor Ultra and event funding (applications reopen January) | Needs review | — |
+| [Devin Ambassadors](https://devin.ai/community) | Cognition (Devin) | Community benefits | Needs review | — |
+| [Kimi Ambassadors](https://www.kimi.ai/lp/kimi-ambassador) | Kimi | Credits and early access | Needs review | — |
+| [Mistral AI Ambassadors](https://docs.mistral.ai/community/ambassadors) | Mistral | Studio API credits, early access | Needs review | — |
+| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | API credits ($50–$100/month) | Needs review | — |
+
+---
+
+## Data quality
+
+- **Active** means an official source confirms availability and the record was verified within the last 30 days.
+- **Needs review** means the record is in the curated dataset but its current availability or terms still need manual confirmation.
+- **Paused** and **Expired** records are retained for provenance but are not active opportunities.
+- A successful link check does not by itself prove that a program is accepting applications.
+
+See [DATA.md](DATA.md) for the schema and verification policy.
 
 ---
 
 ## Contributing
 
-Contributions are welcome!
+Contributions are welcome! Edit [data/programs.json](data/programs.json) rather than editing this README directly.
 
-Before adding a program:
+Before opening a pull request:
 
-* Link to the official program page
-* Make sure the program is still active
-* Note geographic or school eligibility limits when they apply
-* Avoid affiliate or referral links
-* Keep each section alphabetically sorted by program name
+- Link to the official program page
+- Make sure the current status and benefit are supported by the source
+- Note geographic, school, funding, or age eligibility limits when they apply
+- Add last_verified_at and verification notes for active records
+- Avoid affiliate or referral links
+- Run node scripts/validate-programs.mjs
+- Run node scripts/generate-readme.mjs
 
-**Format for adding a new program:**
-
-```markdown
-| [Program Name](https://official-page.com) | Provider | Description of benefits |
-```
-
-Submit a pull request to add new programs.
+Submit a pull request with a short explanation of the change.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 * [Startups](#startups)
 * [AI and Developer Credits](#ai-and-developer-credits)
 * [Ambassadors](#ambassadors)
+* [Needs review](#needs-review)
 * [Data quality](#data-quality)
 * [Contributing](#contributing)
 
@@ -127,10 +128,30 @@ The canonical structured dataset is [data/programs.json](data/programs.json).
 
 ---
 
+## Needs review
+
+These records are retained because the program may still exist, but its current offer or availability could not be confirmed from a readable public source. They are not presented as active opportunities until verified.
+
+| Program | Provider | Benefit | Why it needs review | Checked |
+|---|---|---|---|---|
+| [Atlas Cloud for Open Source](https://www.atlascloud.ai/oss-program) | Atlas Cloud | OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage | Official OSS URL checked 2026-09-10 and redirected to the general Atlas Cloud homepage; the claimed OSS credit amount and application flow could not be independently verified. | 2026-09-10 |
+| [Google AI Pro for Students](https://one.google.com/ai-student) | Google | Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in | Official link checked 2026-09-10 but redirects to Google Accounts sign-in; public benefit, eligibility, and current claim window could not be independently verified. | 2026-09-10 |
+| [Google Summer of Code](https://summerofcode.withgoogle.com/) | Google | Mentored open-source contribution program; stipend and dates vary by annual cycle | Official homepage checked 2026-09-10: program and how-to-apply materials are present, but no current 2026 application dates or stipend terms were exposed in the public page snapshot. | 2026-09-10 |
+| [Hugging Face Startups](https://huggingface.co/startups) | Hugging Face | Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms | Official URL checked 2026-09-10 but resolves to a public Hugging Face profile named startupsdao with no startup-program benefits or application terms; requires manual review. | 2026-09-10 |
+| [JetBrains Student Pack](https://www.jetbrains.com/academy/student-pack/) | JetBrains | Student Pack terms not re-confirmed on the public page snapshot | Official URL checked 2026-09-10 but returned no readable program terms; current student-pack availability requires manual review. | 2026-09-10 |
+| [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) | Linux Foundation | Mentorship terms and stipend not re-confirmed on the public page snapshot | Official URL checked 2026-09-10 but no readable public content was returned; current mentorship rounds and stipends require manual review. | 2026-09-10 |
+| [Mixpanel](https://mixpanel.com/startups-apply/) | Mixpanel | Startup offer could not be re-confirmed; public URL returned only an embedded form shell | Official URL checked 2026-09-10 but the page exposed only an iframe shell with no readable offer terms; current Mixpanel startup benefit requires manual review. | 2026-09-10 |
+| [PlanetScale for Startups](https://planetscale.com/startups) | PlanetScale | Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up | Official PlanetScale page checked 2026-09-10: startup landing page is live, but no startup credit amount or dedicated offer was publicly stated; only free sign-up and paid pricing were visible. | 2026-09-10 |
+| [Qwen Ambassadors](https://qwen.ai/ambassador) | Alibaba Qwen | Ambassador offer could not be re-confirmed; official URL returned no readable public content | Official URL checked 2026-09-10 but returned no readable public content; current Qwen ambassador benefits and application status require manual review. | 2026-09-10 |
+| [Sentry for Startups](https://sentry.io/for/startups/) | Sentry | Startup offer could not be re-confirmed; official URL rendered only a terminal shell | Official URL checked 2026-09-10 but rendered only a terminal shell with no readable program terms; current Sentry offer requires manual review. | 2026-09-10 |
+| [ZAI Startups](https://startup.z.ai/) | Z.AI | Startup API-credit offer could not be re-confirmed; official URL returned an internal error | Official URL checked 2026-09-10 but returned an internal error with no readable program terms; current Z.AI startup offer requires manual review. | 2026-09-10 |
+
+---
+
 ## Data quality
 
 - **Active** means an official source confirms availability and the record was verified within the last 30 days.
-- **Needs review** means the record is in the curated dataset but its current availability or terms still need manual confirmation.
+- **Needs review** means the record may still exist, but its current availability or terms could not be confirmed; it is retained separately and is not an active recommendation.
 - **Paused** and **Expired** records are retained for provenance but are not active opportunities.
 - A successful link check does not by itself prove that a program is accepting applications.
 

--- a/data/programs.json
+++ b/data/programs.json
@@ -176,118 +176,6 @@
       "verification_notes": "Official education page checked 2026-09-10: program lists 1,000+ institutions in 65 countries and student, faculty, administrator, and IT pathways; exact plan entitlements vary by institution."
     },
     {
-      "slug": "google-ai-pro-for-students",
-      "name": "Google AI Pro for Students",
-      "provider": "Google",
-      "categories": [
-        "students"
-      ],
-      "program_type": [
-        "student_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in"
-        }
-      ],
-      "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://one.google.com/ai-student",
-      "official_url": "https://one.google.com/ai-student",
-      "source_urls": [
-        "https://one.google.com/ai-student"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official link checked 2026-09-10 but redirects to Google Accounts sign-in; public benefit, eligibility, and current claim window could not be independently verified."
-    },
-    {
-      "slug": "google-summer-of-code",
-      "name": "Google Summer of Code",
-      "provider": "Google",
-      "categories": [
-        "students"
-      ],
-      "program_type": [
-        "student_program"
-      ],
-      "benefits": [
-        {
-          "type": "stipend",
-          "label": "Mentored open-source contribution program; stipend and dates vary by annual cycle"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "student",
-          "early-career"
-        ],
-        "regions": [],
-        "requirements": [
-          "Apply to a listed open-source organization during the annual cycle"
-        ]
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://summerofcode.withgoogle.com/",
-      "official_url": "https://summerofcode.withgoogle.com/",
-      "source_urls": [
-        "https://summerofcode.withgoogle.com/"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "official_page",
-      "verification_notes": "Official homepage checked 2026-09-10: program and how-to-apply materials are present, but no current 2026 application dates or stipend terms were exposed in the public page snapshot."
-    },
-    {
-      "slug": "jetbrains-student-pack",
-      "name": "JetBrains Student Pack",
-      "provider": "JetBrains",
-      "categories": [
-        "students"
-      ],
-      "program_type": [
-        "student_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Student Pack terms not re-confirmed on the public page snapshot"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "student"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://www.jetbrains.com/academy/student-pack/",
-      "official_url": "https://www.jetbrains.com/academy/student-pack/",
-      "source_urls": [
-        "https://www.jetbrains.com/academy/student-pack/"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but returned no readable program terms; current student-pack availability requires manual review."
-    },
-    {
       "slug": "kiro-for-students",
       "name": "Kiro for Students",
       "provider": "Kiro (AWS)",
@@ -329,44 +217,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Kiro Students page checked 2026-09-10: eligible university students receive 1,000 credits/month free for one year; page includes sign-up/verification and an eligible-school list."
-    },
-    {
-      "slug": "lfx-mentorship",
-      "name": "LFX Mentorship",
-      "provider": "Linux Foundation",
-      "categories": [
-        "students"
-      ],
-      "program_type": [
-        "student_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Mentorship terms and stipend not re-confirmed on the public page snapshot"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "student",
-          "early-career"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://mentorship.lfx.linuxfoundation.org/",
-      "official_url": "https://mentorship.lfx.linuxfoundation.org/",
-      "source_urls": [
-        "https://mentorship.lfx.linuxfoundation.org/"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but no readable public content was returned; current mentorship rounds and stipends require manual review."
     },
     {
       "slug": "manus-campus-for-students",
@@ -726,44 +576,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Zed Education page checked 2026-09-10: accredited university students worldwide can verify enrollment; one-year Student Plan includes Pro features and $10/month in AI token credits."
-    },
-    {
-      "slug": "atlas-cloud-for-open-source",
-      "name": "Atlas Cloud for Open Source",
-      "provider": "Atlas Cloud",
-      "categories": [
-        "open_source"
-      ],
-      "program_type": [
-        "open_source_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "maintainer",
-          "contributor"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://www.atlascloud.ai/oss-program",
-      "official_url": "https://www.atlascloud.ai/oss-program",
-      "source_urls": [
-        "https://www.atlascloud.ai/oss-program"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official OSS URL checked 2026-09-10 and redirected to the general Atlas Cloud homepage; the claimed OSS credit amount and application flow could not be independently verified."
     },
     {
       "slug": "capy-ai-oss",
@@ -1859,43 +1671,6 @@
       "verification_notes": "Official Miro Startups page checked 2026-09-10: early startups can get free Miro credits, scale-ups up to 25% discount, and the page links both offer flows."
     },
     {
-      "slug": "mixpanel",
-      "name": "Mixpanel",
-      "provider": "Mixpanel",
-      "categories": [
-        "startups"
-      ],
-      "program_type": [
-        "startup_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup offer could not be re-confirmed; public URL returned only an embedded form shell"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://mixpanel.com/startups-apply/",
-      "official_url": "https://mixpanel.com/startups-apply/",
-      "source_urls": [
-        "https://mixpanel.com/startups-apply/"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but the page exposed only an iframe shell with no readable offer terms; current Mixpanel startup benefit requires manual review."
-    },
-    {
       "slug": "modal",
       "name": "Modal",
       "provider": "Modal",
@@ -2150,43 +1925,6 @@
       "verification_notes": "Official OVHcloud Startup Program page checked 2026-09-10: it advertises up to €100k in free cloud credit, engineering consultation, and a live Apply flow."
     },
     {
-      "slug": "planetscale-for-startups",
-      "name": "PlanetScale for Startups",
-      "provider": "PlanetScale",
-      "categories": [
-        "startups"
-      ],
-      "program_type": [
-        "startup_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://planetscale.com/startups",
-      "official_url": "https://planetscale.com/startups",
-      "source_urls": [
-        "https://planetscale.com/startups"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "official_page",
-      "verification_notes": "Official PlanetScale page checked 2026-09-10: startup landing page is live, but no startup credit amount or dedicated offer was publicly stated; only free sign-up and paid pricing were visible."
-    },
-    {
       "slug": "posthog-for-startups",
       "name": "PostHog for Startups",
       "provider": "PostHog",
@@ -2322,43 +2060,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Retool page checked 2026-09-10: eligible startups get one year free up to $60k, 25% off the following year, and a live application flow."
-    },
-    {
-      "slug": "sentry-for-startups",
-      "name": "Sentry for Startups",
-      "provider": "Sentry",
-      "categories": [
-        "startups"
-      ],
-      "program_type": [
-        "startup_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup offer could not be re-confirmed; official URL rendered only a terminal shell"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://sentry.io/for/startups/",
-      "official_url": "https://sentry.io/for/startups/",
-      "source_urls": [
-        "https://sentry.io/for/startups/"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but rendered only a terminal shell with no readable program terms; current Sentry offer requires manual review."
     },
     {
       "slug": "stripe-atlas",
@@ -2532,43 +2233,6 @@
       "verification_notes": "Official YC application page checked 2026-09-10: online applications are open; page states an on-time November 2 deadline and says late applications may still be considered."
     },
     {
-      "slug": "zai-startups",
-      "name": "ZAI Startups",
-      "provider": "Z.AI",
-      "categories": [
-        "startups"
-      ],
-      "program_type": [
-        "startup_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup API-credit offer could not be re-confirmed; official URL returned an internal error"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://startup.z.ai/",
-      "official_url": "https://startup.z.ai/",
-      "source_urls": [
-        "https://startup.z.ai/"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but returned an internal error with no readable program terms; current Z.AI startup offer requires manual review."
-    },
-    {
       "slug": "anthropic-startup-program",
       "name": "Anthropic Startup Program",
       "provider": "Anthropic",
@@ -2610,43 +2274,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Claude for Startups page checked 2026-09-10: application is open; credits/extras require institutional equity funding, a company founded within four years, and no prior Anthropic startup credits."
-    },
-    {
-      "slug": "hugging-face-startups",
-      "name": "Hugging Face Startups",
-      "provider": "Hugging Face",
-      "categories": [
-        "ai_developer_credits"
-      ],
-      "program_type": [
-        "developer_credits"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://huggingface.co/startups",
-      "official_url": "https://huggingface.co/startups",
-      "source_urls": [
-        "https://huggingface.co/startups"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but resolves to a public Hugging Face profile named startupsdao with no startup-program benefits or application terms; requires manual review."
     },
     {
       "slug": "openai-startup-program",
@@ -2703,7 +2330,7 @@
         {
           "type": "credits",
           "label": "Small research grants of a few hundred dollars for eligible student projects",
-        "value": "few hundred",
+          "value": "few hundred",
           "currency": "USD",
           "duration": "grant"
         }
@@ -3043,44 +2670,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Mistral Docs page checked 2026-09-10: applications are open on a rolling basis; page lists technical, community, communication, and time-commitment requirements."
-    },
-    {
-      "slug": "qwen-ambassadors",
-      "name": "Qwen Ambassadors",
-      "provider": "Alibaba Qwen",
-      "categories": [
-        "ambassadors"
-      ],
-      "program_type": [
-        "ambassador_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Ambassador offer could not be re-confirmed; official URL returned no readable public content"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "developer",
-          "community_builder"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://qwen.ai/ambassador",
-      "official_url": "https://qwen.ai/ambassador",
-      "source_urls": [
-        "https://qwen.ai/ambassador"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but returned no readable public content; current Qwen ambassador benefits and application status require manual review."
     }
   ]
 }

--- a/data/programs.json
+++ b/data/programs.json
@@ -187,28 +187,38 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in"
+          "type": "subscription",
+          "label": "Discounted Google AI Pro while enrolled; eligible regions may receive a 12-month Google AI Plus student trial",
+          "duration": "Up to 4 consecutive years while eligible"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "student"
+        ],
+        "regions": [
+          "eligible supported countries"
+        ],
+        "requirements": [
+          "Be enrolled at a higher-education institution",
+          "Verify student status through SheerID with a valid school email",
+          "Use a personal Google Account and qualifying payment method"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://one.google.com/ai-student",
-      "official_url": "https://one.google.com/ai-student",
+      "official_url": "https://support.google.com/googleone/answer/17422238?hl=en",
       "source_urls": [
+        "https://support.google.com/googleone/answer/17422238?hl=en",
         "https://one.google.com/ai-student"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": false,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official link checked 2026-09-10 but redirects to Google Accounts sign-in; public benefit, eligibility, and current claim window could not be independently verified."
+      "verification_method": "official_page",
+      "verification_notes": "Official Google support article checked 2026-09-10: eligible students can claim Google AI Pro while enrolled for up to four consecutive years; eligible countries may receive a 12-month Google AI Plus trial. SheerID verification, a personal Google Account, and a qualifying payment method are required; the exact offer varies by country."
     },
     {
       "slug": "google-summer-of-code",
@@ -223,32 +233,43 @@
       "benefits": [
         {
           "type": "stipend",
-          "label": "Mentored open-source contribution program; stipend and dates vary by annual cycle"
+          "label": "PPP-adjusted stipend for an 8–22 week mentored open-source project",
+          "value": "$750–$6,600",
+          "currency": "USD (PPP-adjusted)",
+          "duration": "8–22 weeks"
         }
       ],
       "eligibility": {
         "stages": [
           "student",
-          "early-career"
+          "beginner"
         ],
-        "regions": [],
+        "regions": [
+          "global"
+        ],
         "requirements": [
-          "Apply to a listed open-source organization during the annual cycle"
+          "Be at least 18 at registration",
+          "Be a student or open-source beginner",
+          "Be eligible to work in the country of residence",
+          "Submit a proposal through the GSoC site"
         ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
+      "status": "paused",
+      "application_state": "closed",
+      "deadline": "2026-03-31",
       "application_url": "https://summerofcode.withgoogle.com/",
-      "official_url": "https://summerofcode.withgoogle.com/",
+      "official_url": "https://developers.google.com/open-source/gsoc/timeline",
       "source_urls": [
+        "https://developers.google.com/open-source/gsoc/timeline",
+        "https://developers.google.com/open-source/gsoc/help/student-stipends",
+        "https://developers.google.com/open-source/gsoc/faq",
         "https://summerofcode.withgoogle.com/"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": false,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
-      "verification_notes": "Official homepage checked 2026-09-10: program and how-to-apply materials are present, but no current 2026 application dates or stipend terms were exposed in the public page snapshot."
+      "verification_notes": "Official 2026 timeline, stipend, and FAQ pages checked 2026-09-10: contributor applications ran March 16–31, 2026; stipends are PPP-adjusted and range from $750 to $6,600. The 2026 contributor window is closed, so this record is paused until the next annual cycle."
     },
     {
       "slug": "jetbrains-student-pack",
@@ -262,30 +283,37 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Student Pack terms not re-confirmed on the public page snapshot"
+          "type": "software",
+          "label": "Free JetBrains professional IDEs for verified students",
+          "duration": "While eligible"
         }
       ],
       "eligibility": {
         "stages": [
           "student"
         ],
-        "regions": [],
-        "requirements": []
+        "regions": [
+          "global"
+        ],
+        "requirements": [
+          "Use a school email, student ID, ISIC card, or another official student document"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
-      "application_url": "https://www.jetbrains.com/academy/student-pack/",
-      "official_url": "https://www.jetbrains.com/academy/student-pack/",
+      "application_url": "https://www.jetbrains.com/shop/eform/students",
+      "official_url": "https://www.jetbrains.com/education/",
       "source_urls": [
-        "https://www.jetbrains.com/academy/student-pack/"
+        "https://www.jetbrains.com/education/",
+        "https://www.jetbrains.com/academy/student-pack/",
+        "https://www.jetbrains.com/shop/eform/students"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": true,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but returned no readable program terms; current student-pack availability requires manual review."
+      "verification_method": "official_page",
+      "verification_notes": "Official JetBrains Education page checked 2026-09-10: professional IDEs are free for students with a school email, student ID, ISIC card, or another official document; its Apply now link reaches the student application form."
     },
     {
       "slug": "kiro-for-students",
@@ -342,8 +370,9 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Mentorship terms and stipend not re-confirmed on the public page snapshot"
+          "type": "stipend",
+          "label": "Open-source mentorship with a stipend; amount varies by program and region",
+          "duration": "Cohort"
         }
       ],
       "eligibility": {
@@ -351,22 +380,30 @@
           "student",
           "early-career"
         ],
-        "regions": [],
-        "requirements": []
+        "regions": [
+          "varies by cohort"
+        ],
+        "requirements": [
+          "Create a mentee profile on the LFX Mentorship platform",
+          "Apply to an available Linux Foundation mentorship program",
+          "Check each cohort for its specific eligibility and dates"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "rolling",
       "deadline": null,
-      "application_url": "https://mentorship.lfx.linuxfoundation.org/",
-      "official_url": "https://mentorship.lfx.linuxfoundation.org/",
+      "application_url": "https://mentorship.lfx.dev/",
+      "official_url": "https://lfx.linuxfoundation.org/tools/mentorship/",
       "source_urls": [
-        "https://mentorship.lfx.linuxfoundation.org/"
+        "https://lfx.linuxfoundation.org/tools/mentorship/",
+        "https://docs.linuxfoundation.org/lfx/mentorship",
+        "https://mentorship.lfx.dev/"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": true,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but no readable public content was returned; current mentorship rounds and stipends require manual review."
+      "verification_method": "official_page",
+      "verification_notes": "Official Linux Foundation Mentorship page and documentation checked 2026-09-10: the platform is live, mentees create a profile and apply to available programs, and the program advertises stipends; cohort availability and terms vary by program."
     },
     {
       "slug": "manus-campus-for-students",
@@ -726,44 +763,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Zed Education page checked 2026-09-10: accredited university students worldwide can verify enrollment; one-year Student Plan includes Pro features and $10/month in AI token credits."
-    },
-    {
-      "slug": "atlas-cloud-for-open-source",
-      "name": "Atlas Cloud for Open Source",
-      "provider": "Atlas Cloud",
-      "categories": [
-        "open_source"
-      ],
-      "program_type": [
-        "open_source_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "maintainer",
-          "contributor"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://www.atlascloud.ai/oss-program",
-      "official_url": "https://www.atlascloud.ai/oss-program",
-      "source_urls": [
-        "https://www.atlascloud.ai/oss-program"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official OSS URL checked 2026-09-10 and redirected to the general Atlas Cloud homepage; the claimed OSS credit amount and application flow could not be independently verified."
     },
     {
       "slug": "capy-ai-oss",
@@ -1870,30 +1869,39 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Startup offer could not be re-confirmed; public URL returned only an embedded form shell"
+          "type": "software",
+          "label": "Mixpanel Startup Plan free for 12 months, up to 1B events per year",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
         "stages": [
           "startup"
         ],
-        "regions": [],
-        "requirements": []
+        "regions": [
+          "global"
+        ],
+        "requirements": [
+          "Be incorporated less than five years ago",
+          "Have raised no more than $8M total",
+          "Have no previous Mixpanel exclusive offer or paid plan",
+          "Begin sending data within 90 days of acceptance"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://mixpanel.com/startups-apply/",
-      "official_url": "https://mixpanel.com/startups-apply/",
+      "official_url": "https://docs.mixpanel.com/docs/pricing/startup-program",
       "source_urls": [
+        "https://docs.mixpanel.com/docs/pricing/startup-program",
         "https://mixpanel.com/startups-apply/"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": true,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but the page exposed only an iframe shell with no readable offer terms; current Mixpanel startup benefit requires manual review."
+      "verification_method": "official_page",
+      "verification_notes": "Official Mixpanel Startup Program documentation checked 2026-09-10: the first year is free on the Startup Plan for startups incorporated under five years, with no more than $8M raised and no prior exclusive offer or paid plan; accepted companies must send data within 90 days. The application flow is open."
     },
     {
       "slug": "modal",
@@ -2150,43 +2158,6 @@
       "verification_notes": "Official OVHcloud Startup Program page checked 2026-09-10: it advertises up to €100k in free cloud credit, engineering consultation, and a live Apply flow."
     },
     {
-      "slug": "planetscale-for-startups",
-      "name": "PlanetScale for Startups",
-      "provider": "PlanetScale",
-      "categories": [
-        "startups"
-      ],
-      "program_type": [
-        "startup_program"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://planetscale.com/startups",
-      "official_url": "https://planetscale.com/startups",
-      "source_urls": [
-        "https://planetscale.com/startups"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "official_page",
-      "verification_notes": "Official PlanetScale page checked 2026-09-10: startup landing page is live, but no startup credit amount or dedicated offer was publicly stated; only free sign-up and paid pricing were visible."
-    },
-    {
       "slug": "posthog-for-startups",
       "name": "PostHog for Startups",
       "provider": "PostHog",
@@ -2335,30 +2306,48 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Startup offer could not be re-confirmed; official URL rendered only a terminal shell"
+          "type": "credits",
+          "label": "Sentry credits",
+          "value": 5000,
+          "currency": "USD",
+          "duration": "12 months"
+        },
+        {
+          "type": "support",
+          "label": "Priority support"
+        },
+        {
+          "type": "swag",
+          "label": "Sentry swag"
         }
       ],
       "eligibility": {
         "stages": [
           "startup"
         ],
-        "regions": [],
-        "requirements": []
+        "regions": [
+          "global"
+        ],
+        "requirements": [
+          "Be founded within the last two years",
+          "Have raised less than $5M in venture capital",
+          "Be new to paying for Sentry"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
-      "application_url": "https://sentry.io/for/startups/",
+      "application_url": "https://sentry.io/for/startups/apply/",
       "official_url": "https://sentry.io/for/startups/",
       "source_urls": [
-        "https://sentry.io/for/startups/"
+        "https://sentry.io/for/startups/",
+        "https://sentry.io/for/startups/apply/"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": true,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
       "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but rendered only a terminal shell with no readable program terms; current Sentry offer requires manual review."
+      "verification_notes": "Official Sentry for Startups page and application form checked live 2026-09-10: the program offers up to $5,000 in credits expiring after 12 months, priority support, and swag. Eligibility is a company founded within two years, less than $5M in venture capital, and new to paying for Sentry."
     },
     {
       "slug": "stripe-atlas",
@@ -2543,30 +2532,36 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Startup API-credit offer could not be re-confirmed; official URL returned an internal error"
+          "type": "credits",
+          "label": "Free Z.ai API credits up to 1B tokens, plus priority support, early API access, and startup community access",
+          "value": "Up to 1B tokens"
         }
       ],
       "eligibility": {
         "stages": [
           "startup"
         ],
-        "regions": [],
-        "requirements": []
+        "regions": [
+          "global"
+        ],
+        "requirements": [
+          "Submit startup details and vision through the Z.ai application form",
+          "Receive approval from the Z.ai Startups team"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
-      "application_url": "https://startup.z.ai/",
+      "application_url": "https://startup.z.ai/#apply",
       "official_url": "https://startup.z.ai/",
       "source_urls": [
         "https://startup.z.ai/"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": true,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
       "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but returned an internal error with no readable program terms; current Z.AI startup offer requires manual review."
+      "verification_notes": "Official Z.ai Startups page checked live 2026-09-10: it advertises up to 1B free API-token credits, priority support, an exclusive founder community, early API access, and an application reviewed by Z.ai. No fixed deadline is shown."
     },
     {
       "slug": "anthropic-startup-program",
@@ -2610,43 +2605,6 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Claude for Startups page checked 2026-09-10: application is open; credits/extras require institutional equity funding, a company founded within four years, and no prior Anthropic startup credits."
-    },
-    {
-      "slug": "hugging-face-startups",
-      "name": "Hugging Face Startups",
-      "provider": "Hugging Face",
-      "categories": [
-        "ai_developer_credits"
-      ],
-      "program_type": [
-        "developer_credits"
-      ],
-      "benefits": [
-        {
-          "type": "unspecified",
-          "label": "Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms"
-        }
-      ],
-      "eligibility": {
-        "stages": [
-          "startup"
-        ],
-        "regions": [],
-        "requirements": []
-      },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
-      "application_url": "https://huggingface.co/startups",
-      "official_url": "https://huggingface.co/startups",
-      "source_urls": [
-        "https://huggingface.co/startups"
-      ],
-      "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": "2026-09-10",
-      "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but resolves to a public Hugging Face profile named startupsdao with no startup-program benefits or application terms; requires manual review."
     },
     {
       "slug": "openai-startup-program",
@@ -2703,7 +2661,7 @@
         {
           "type": "credits",
           "label": "Small research grants of a few hundred dollars for eligible student projects",
-        "value": "few hundred",
+          "value": "few hundred",
           "currency": "USD",
           "duration": "grant"
         }
@@ -3056,8 +3014,15 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Ambassador offer could not be re-confirmed; official URL returned no readable public content"
+          "type": "credits",
+          "label": "Qwen API credits of $50–$100 per month for active ambassadors",
+          "value": "$50–$100/month",
+          "currency": "USD",
+          "duration": "Monthly while active"
+        },
+        {
+          "type": "community",
+          "label": "Early access to Qwen models, private team chats, community badge, merchandise, and event support"
         }
       ],
       "eligibility": {
@@ -3065,22 +3030,29 @@
           "developer",
           "community_builder"
         ],
-        "regions": [],
-        "requirements": []
+        "regions": [
+          "global"
+        ],
+        "requirements": [
+          "Apply as a Dev Ambassador or Event Ambassador",
+          "Dev Ambassadors publish at least four Qwen-related outputs per month for $100 monthly credits",
+          "Event Ambassadors run at least one event and two Qwen-related social posts per month for $100 monthly credits"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
-      "application_url": "https://qwen.ai/ambassador",
+      "application_url": "https://alidocs.dingtalk.com/notable/share/form/v01J9LnW6jR1E0aalvD_dv19yqvsgs3oebp3pcjys_1qX0QQ0?source=link",
       "official_url": "https://qwen.ai/ambassador",
       "source_urls": [
-        "https://qwen.ai/ambassador"
+        "https://qwen.ai/ambassador",
+        "https://alidocs.dingtalk.com/notable/share/form/v01J9LnW6jR1E0aalvD_dv19yqvsgs3oebp3pcjys_1qX0QQ0?source=link"
       ],
-      "separate_application": null,
-      "referral_only": null,
+      "separate_application": true,
+      "referral_only": false,
       "last_verified_at": "2026-09-10",
       "verification_method": "manual_review",
-      "verification_notes": "Official URL checked 2026-09-10 but returned no readable public content; current Qwen ambassador benefits and application status require manual review."
+      "verification_notes": "Official Qwen Ambassador page checked live 2026-09-10: Dev and Event Ambassador roles, an application form, $50–$100 monthly API credits, early model access, private community access, merchandise, and event support are listed. The page states that $100 monthly credits require the role-specific contribution thresholds."
     }
   ]
 }

--- a/data/programs.json
+++ b/data/programs.json
@@ -176,6 +176,118 @@
       "verification_notes": "Official education page checked 2026-09-10: program lists 1,000+ institutions in 65 countries and student, faculty, administrator, and IT pathways; exact plan entitlements vary by institution."
     },
     {
+      "slug": "google-ai-pro-for-students",
+      "name": "Google AI Pro for Students",
+      "provider": "Google",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://one.google.com/ai-student",
+      "official_url": "https://one.google.com/ai-student",
+      "source_urls": [
+        "https://one.google.com/ai-student"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official link checked 2026-09-10 but redirects to Google Accounts sign-in; public benefit, eligibility, and current claim window could not be independently verified."
+    },
+    {
+      "slug": "google-summer-of-code",
+      "name": "Google Summer of Code",
+      "provider": "Google",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "stipend",
+          "label": "Mentored open-source contribution program; stipend and dates vary by annual cycle"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "student",
+          "early-career"
+        ],
+        "regions": [],
+        "requirements": [
+          "Apply to a listed open-source organization during the annual cycle"
+        ]
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://summerofcode.withgoogle.com/",
+      "official_url": "https://summerofcode.withgoogle.com/",
+      "source_urls": [
+        "https://summerofcode.withgoogle.com/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official homepage checked 2026-09-10: program and how-to-apply materials are present, but no current 2026 application dates or stipend terms were exposed in the public page snapshot."
+    },
+    {
+      "slug": "jetbrains-student-pack",
+      "name": "JetBrains Student Pack",
+      "provider": "JetBrains",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Student Pack terms not re-confirmed on the public page snapshot"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "student"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.jetbrains.com/academy/student-pack/",
+      "official_url": "https://www.jetbrains.com/academy/student-pack/",
+      "source_urls": [
+        "https://www.jetbrains.com/academy/student-pack/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but returned no readable program terms; current student-pack availability requires manual review."
+    },
+    {
       "slug": "kiro-for-students",
       "name": "Kiro for Students",
       "provider": "Kiro (AWS)",
@@ -217,6 +329,44 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Kiro Students page checked 2026-09-10: eligible university students receive 1,000 credits/month free for one year; page includes sign-up/verification and an eligible-school list."
+    },
+    {
+      "slug": "lfx-mentorship",
+      "name": "LFX Mentorship",
+      "provider": "Linux Foundation",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Mentorship terms and stipend not re-confirmed on the public page snapshot"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "student",
+          "early-career"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://mentorship.lfx.linuxfoundation.org/",
+      "official_url": "https://mentorship.lfx.linuxfoundation.org/",
+      "source_urls": [
+        "https://mentorship.lfx.linuxfoundation.org/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but no readable public content was returned; current mentorship rounds and stipends require manual review."
     },
     {
       "slug": "manus-campus-for-students",
@@ -576,6 +726,44 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Zed Education page checked 2026-09-10: accredited university students worldwide can verify enrollment; one-year Student Plan includes Pro features and $10/month in AI token credits."
+    },
+    {
+      "slug": "atlas-cloud-for-open-source",
+      "name": "Atlas Cloud for Open Source",
+      "provider": "Atlas Cloud",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "maintainer",
+          "contributor"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.atlascloud.ai/oss-program",
+      "official_url": "https://www.atlascloud.ai/oss-program",
+      "source_urls": [
+        "https://www.atlascloud.ai/oss-program"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official OSS URL checked 2026-09-10 and redirected to the general Atlas Cloud homepage; the claimed OSS credit amount and application flow could not be independently verified."
     },
     {
       "slug": "capy-ai-oss",
@@ -1671,6 +1859,43 @@
       "verification_notes": "Official Miro Startups page checked 2026-09-10: early startups can get free Miro credits, scale-ups up to 25% discount, and the page links both offer flows."
     },
     {
+      "slug": "mixpanel",
+      "name": "Mixpanel",
+      "provider": "Mixpanel",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Startup offer could not be re-confirmed; public URL returned only an embedded form shell"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "startup"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://mixpanel.com/startups-apply/",
+      "official_url": "https://mixpanel.com/startups-apply/",
+      "source_urls": [
+        "https://mixpanel.com/startups-apply/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but the page exposed only an iframe shell with no readable offer terms; current Mixpanel startup benefit requires manual review."
+    },
+    {
       "slug": "modal",
       "name": "Modal",
       "provider": "Modal",
@@ -1925,6 +2150,43 @@
       "verification_notes": "Official OVHcloud Startup Program page checked 2026-09-10: it advertises up to €100k in free cloud credit, engineering consultation, and a live Apply flow."
     },
     {
+      "slug": "planetscale-for-startups",
+      "name": "PlanetScale for Startups",
+      "provider": "PlanetScale",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "startup"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://planetscale.com/startups",
+      "official_url": "https://planetscale.com/startups",
+      "source_urls": [
+        "https://planetscale.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official PlanetScale page checked 2026-09-10: startup landing page is live, but no startup credit amount or dedicated offer was publicly stated; only free sign-up and paid pricing were visible."
+    },
+    {
       "slug": "posthog-for-startups",
       "name": "PostHog for Startups",
       "provider": "PostHog",
@@ -2060,6 +2322,43 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Retool page checked 2026-09-10: eligible startups get one year free up to $60k, 25% off the following year, and a live application flow."
+    },
+    {
+      "slug": "sentry-for-startups",
+      "name": "Sentry for Startups",
+      "provider": "Sentry",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Startup offer could not be re-confirmed; official URL rendered only a terminal shell"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "startup"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://sentry.io/for/startups/",
+      "official_url": "https://sentry.io/for/startups/",
+      "source_urls": [
+        "https://sentry.io/for/startups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but rendered only a terminal shell with no readable program terms; current Sentry offer requires manual review."
     },
     {
       "slug": "stripe-atlas",
@@ -2233,6 +2532,43 @@
       "verification_notes": "Official YC application page checked 2026-09-10: online applications are open; page states an on-time November 2 deadline and says late applications may still be considered."
     },
     {
+      "slug": "zai-startups",
+      "name": "ZAI Startups",
+      "provider": "Z.AI",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Startup API-credit offer could not be re-confirmed; official URL returned an internal error"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "startup"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://startup.z.ai/",
+      "official_url": "https://startup.z.ai/",
+      "source_urls": [
+        "https://startup.z.ai/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but returned an internal error with no readable program terms; current Z.AI startup offer requires manual review."
+    },
+    {
       "slug": "anthropic-startup-program",
       "name": "Anthropic Startup Program",
       "provider": "Anthropic",
@@ -2274,6 +2610,43 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Claude for Startups page checked 2026-09-10: application is open; credits/extras require institutional equity funding, a company founded within four years, and no prior Anthropic startup credits."
+    },
+    {
+      "slug": "hugging-face-startups",
+      "name": "Hugging Face Startups",
+      "provider": "Hugging Face",
+      "categories": [
+        "ai_developer_credits"
+      ],
+      "program_type": [
+        "developer_credits"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "startup"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://huggingface.co/startups",
+      "official_url": "https://huggingface.co/startups",
+      "source_urls": [
+        "https://huggingface.co/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but resolves to a public Hugging Face profile named startupsdao with no startup-program benefits or application terms; requires manual review."
     },
     {
       "slug": "openai-startup-program",
@@ -2330,7 +2703,7 @@
         {
           "type": "credits",
           "label": "Small research grants of a few hundred dollars for eligible student projects",
-          "value": "few hundred",
+        "value": "few hundred",
           "currency": "USD",
           "duration": "grant"
         }
@@ -2670,6 +3043,44 @@
       "last_verified_at": "2026-09-10",
       "verification_method": "official_page",
       "verification_notes": "Official Mistral Docs page checked 2026-09-10: applications are open on a rolling basis; page lists technical, community, communication, and time-commitment requirements."
+    },
+    {
+      "slug": "qwen-ambassadors",
+      "name": "Qwen Ambassadors",
+      "provider": "Alibaba Qwen",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Ambassador offer could not be re-confirmed; official URL returned no readable public content"
+        }
+      ],
+      "eligibility": {
+        "stages": [
+          "developer",
+          "community_builder"
+        ],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://qwen.ai/ambassador",
+      "official_url": "https://qwen.ai/ambassador",
+      "source_urls": [
+        "https://qwen.ai/ambassador"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but returned no readable public content; current Qwen ambassador benefits and application status require manual review."
     }
   ]
 }

--- a/data/programs.json
+++ b/data/programs.json
@@ -1,0 +1,2526 @@
+{
+  "$schema": "./programs.schema.json",
+  "schema_version": 1,
+  "programs": [
+    {
+      "slug": "codex-for-students",
+      "name": "Codex for Students",
+      "provider": "OpenAI",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$100 in Codex credits (US & Canada students only)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://chatgpt.com/codex/students",
+      "official_url": "https://chatgpt.com/codex/students",
+      "source_urls": [
+        "https://chatgpt.com/codex/students"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "figma-for-education",
+      "name": "Figma for Education",
+      "provider": "Figma",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free design tools for students"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.figma.com/education/",
+      "official_url": "https://www.figma.com/education/",
+      "source_urls": [
+        "https://www.figma.com/education/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "github-student-developer-pack",
+      "name": "GitHub Student Developer Pack",
+      "provider": "GitHub",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Developer tools bundle (~$10k value)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://education.github.com/pack",
+      "official_url": "https://education.github.com/pack",
+      "source_urls": [
+        "https://education.github.com/pack"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "gitlab-for-education",
+      "name": "GitLab for Education",
+      "provider": "GitLab",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free GitLab Ultimate for education"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://about.gitlab.com/solutions/education/",
+      "official_url": "https://about.gitlab.com/solutions/education/",
+      "source_urls": [
+        "https://about.gitlab.com/solutions/education/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "google-ai-pro-for-students",
+      "name": "Google AI Pro for Students",
+      "provider": "Google",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "1 year of Google AI Pro (US) or AI Plus (many other countries); claim window through end of 2026"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://one.google.com/ai-student",
+      "official_url": "https://one.google.com/ai-student",
+      "source_urls": [
+        "https://one.google.com/ai-student"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "google-summer-of-code",
+      "name": "Google Summer of Code",
+      "provider": "Google",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Stipend and mentorship for students contributing to OSS"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://summerofcode.withgoogle.com/",
+      "official_url": "https://summerofcode.withgoogle.com/",
+      "source_urls": [
+        "https://summerofcode.withgoogle.com/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "jetbrains-student-pack",
+      "name": "JetBrains Student Pack",
+      "provider": "JetBrains",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free IDE licenses"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.jetbrains.com/academy/student-pack/",
+      "official_url": "https://www.jetbrains.com/academy/student-pack/",
+      "source_urls": [
+        "https://www.jetbrains.com/academy/student-pack/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "kiro-for-students",
+      "name": "Kiro for Students",
+      "provider": "Kiro (AWS)",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "1,000 credits/month free for 1 year (participating universities; SheerID verification)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://kiro.dev/students/",
+      "official_url": "https://kiro.dev/students/",
+      "source_urls": [
+        "https://kiro.dev/students/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "lfx-mentorship",
+      "name": "LFX Mentorship",
+      "provider": "Linux Foundation",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Paid remote OSS mentorship (stipends vary by region)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://mentorship.lfx.linuxfoundation.org/",
+      "official_url": "https://mentorship.lfx.linuxfoundation.org/",
+      "source_urls": [
+        "https://mentorship.lfx.linuxfoundation.org/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "manus-campus-for-students",
+      "name": "Manus Campus for Students",
+      "provider": "Manus",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Campus access; 1,000-credit referral reward per invited student"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://manus.im/edu",
+      "official_url": "https://manus.im/edu",
+      "source_urls": [
+        "https://manus.im/edu"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "microsoft-azure-for-students",
+      "name": "Microsoft Azure for Students",
+      "provider": "Microsoft",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Azure credits and dev tools"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://azure.microsoft.com/en-us/free/students/",
+      "official_url": "https://azure.microsoft.com/en-us/free/students/",
+      "source_urls": [
+        "https://azure.microsoft.com/en-us/free/students/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "mlh-fellowship",
+      "name": "MLH Fellowship",
+      "provider": "Major League Hacking",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "12-week remote fellowship with stipend"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://fellowship.mlh.com/",
+      "official_url": "https://fellowship.mlh.com/",
+      "source_urls": [
+        "https://fellowship.mlh.com/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "openai-student-collective",
+      "name": "OpenAI Student Collective",
+      "provider": "OpenAI",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Campus Lead role: ChatGPT + Codex credits, event funding, and stipend"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://openai.com/student-collective/",
+      "official_url": "https://openai.com/student-collective/",
+      "source_urls": [
+        "https://openai.com/student-collective/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "outreachy",
+      "name": "Outreachy",
+      "provider": "Software Freedom Conservancy",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Paid remote OSS internship (~$7,000 stipend)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.outreachy.org/",
+      "official_url": "https://www.outreachy.org/",
+      "source_urls": [
+        "https://www.outreachy.org/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "v0-for-students",
+      "name": "v0 for Students",
+      "provider": "Vercel",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "1 year of free v0 Premium (limited partner universities)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://v0.app/students",
+      "official_url": "https://v0.app/students",
+      "source_urls": [
+        "https://v0.app/students"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "yc-ai-student-starter-pack",
+      "name": "YC AI Student Starter Pack",
+      "provider": "Y Combinator",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Credits and tools (~$25k value; requires attending a YC student event)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://deals.ycombinator.com/students",
+      "official_url": "https://deals.ycombinator.com/students",
+      "source_urls": [
+        "https://deals.ycombinator.com/students"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "zed-student-plan",
+      "name": "Zed Student Plan",
+      "provider": "Zed",
+      "categories": [
+        "students"
+      ],
+      "program_type": [
+        "student_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "All Zed Pro features for 12 months"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://zed.dev/education",
+      "official_url": "https://zed.dev/education",
+      "source_urls": [
+        "https://zed.dev/education"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "atlas-cloud-for-open-source",
+      "name": "Atlas Cloud for Open Source",
+      "provider": "Atlas Cloud",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $1,500/mo AI credits (400+ models) for active OSS maintainers"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.atlascloud.ai/oss-program",
+      "official_url": "https://www.atlascloud.ai/oss-program",
+      "source_urls": [
+        "https://www.atlascloud.ai/oss-program"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "capy-ai-oss",
+      "name": "Capy AI OSS",
+      "provider": "Capy AI",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Full platform access for open-source projects"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://capy.ai/open-source",
+      "official_url": "https://capy.ai/open-source",
+      "source_urls": [
+        "https://capy.ai/open-source"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "catalyst",
+      "name": "Catalyst",
+      "provider": "Open Core Ventures",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$10,000 sponsorship + 3-month program for eligible OSS authors and maintainers"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://opencoreventures.com/catalyst/",
+      "official_url": "https://opencoreventures.com/catalyst/",
+      "source_urls": [
+        "https://opencoreventures.com/catalyst/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "claude-for-open-source",
+      "name": "Claude for Open Source",
+      "provider": "Anthropic",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "6 months of Claude Max"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://claude.com/contact-sales/claude-for-oss",
+      "official_url": "https://claude.com/contact-sales/claude-for-oss",
+      "source_urls": [
+        "https://claude.com/contact-sales/claude-for-oss"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "github-secure-open-source-fund",
+      "name": "GitHub Secure Open Source Fund",
+      "provider": "GitHub",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$10,000 project funding, $10,000 Azure credits, Copilot Pro, and a 3-week security program"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://github.com/open-source/github-secure-open-source-fund",
+      "official_url": "https://github.com/open-source/github-secure-open-source-fund",
+      "source_urls": [
+        "https://github.com/open-source/github-secure-open-source-fund"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "microsoft-foss-fund",
+      "name": "Microsoft FOSS Fund",
+      "provider": "Microsoft",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $12,500 USD for selected projects"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://github.com/microsoft/foss-fund",
+      "official_url": "https://github.com/microsoft/foss-fund",
+      "source_urls": [
+        "https://github.com/microsoft/foss-fund"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "ona-for-open-source",
+      "name": "Ona for Open Source",
+      "provider": "Ona",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $200/mo AI credits for OSS maintainers and contributors"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://ona.com/stories/ona-for-open-source",
+      "official_url": "https://ona.com/stories/ona-for-open-source",
+      "source_urls": [
+        "https://ona.com/stories/ona-for-open-source"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "openai-codex-for-open-source",
+      "name": "OpenAI Codex for Open Source",
+      "provider": "OpenAI",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "6 months of ChatGPT Pro with Codex, plus API credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://developers.openai.com/community/codex-for-oss",
+      "official_url": "https://developers.openai.com/community/codex-for-oss",
+      "source_urls": [
+        "https://developers.openai.com/community/codex-for-oss"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "snyk-for-open-source",
+      "name": "Snyk for Open Source",
+      "provider": "Snyk",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Full Snyk platform free for qualifying OSS maintainers"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://snyk.io/open-source",
+      "official_url": "https://snyk.io/open-source",
+      "source_urls": [
+        "https://snyk.io/open-source"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "upstash-for-open-source",
+      "name": "Upstash for Open Source",
+      "provider": "Upstash",
+      "categories": [
+        "open_source"
+      ],
+      "program_type": [
+        "open_source_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$1,000 monthly credit grant"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://upstash.com/open-source",
+      "official_url": "https://upstash.com/open-source",
+      "source_urls": [
+        "https://upstash.com/open-source"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "assemblyai-startup-program",
+      "name": "AssemblyAI Startup Program",
+      "provider": "AssemblyAI",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "12 months free credits for voice/speech AI"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.assemblyai.com/contact/startup-program",
+      "official_url": "https://www.assemblyai.com/contact/startup-program",
+      "source_urls": [
+        "https://www.assemblyai.com/contact/startup-program"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "aws-activate",
+      "name": "AWS Activate",
+      "provider": "AWS",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Cloud credits (up to $100k)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://aws.amazon.com/startups/credits",
+      "official_url": "https://aws.amazon.com/startups/credits",
+      "source_urls": [
+        "https://aws.amazon.com/startups/credits"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "circleci-for-startups",
+      "name": "CircleCI for Startups",
+      "provider": "CircleCI",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $20,000 in compute credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://circleci.com/startup-program/",
+      "official_url": "https://circleci.com/startup-program/",
+      "source_urls": [
+        "https://circleci.com/startup-program/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "clerk-for-startups",
+      "name": "Clerk for Startups",
+      "provider": "Clerk",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Clerk Pro at a discount for early-stage startups"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://clerk.com/startups",
+      "official_url": "https://clerk.com/startups",
+      "source_urls": [
+        "https://clerk.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "cloudflare-for-startups",
+      "name": "Cloudflare for Startups",
+      "provider": "Cloudflare",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $350,000 in Cloudflare credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.cloudflare.com/forstartups/",
+      "official_url": "https://www.cloudflare.com/forstartups/",
+      "source_urls": [
+        "https://www.cloudflare.com/forstartups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "databricks-startup-program",
+      "name": "Databricks Startup Program",
+      "provider": "Databricks",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $200k in credits across Databricks and Neon"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.databricks.com/product/startups",
+      "official_url": "https://www.databricks.com/product/startups",
+      "source_urls": [
+        "https://www.databricks.com/product/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "datadog-for-startups",
+      "name": "Datadog for Startups",
+      "provider": "Datadog",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "A year of free Datadog Pro"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.datadoghq.com/partner/datadog-for-startups/",
+      "official_url": "https://www.datadoghq.com/partner/datadog-for-startups/",
+      "source_urls": [
+        "https://www.datadoghq.com/partner/datadog-for-startups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "daytona",
+      "name": "Daytona",
+      "provider": "Daytona",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $50k in Daytona credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.daytona.io/startups",
+      "official_url": "https://www.daytona.io/startups",
+      "source_urls": [
+        "https://www.daytona.io/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "deepgram-for-startups",
+      "name": "Deepgram for Startups",
+      "provider": "Deepgram",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $100,000 in voice AI credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://deepgram.com/startup-program",
+      "official_url": "https://deepgram.com/startup-program",
+      "source_urls": [
+        "https://deepgram.com/startup-program"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "devin-for-startups",
+      "name": "Devin for Startups",
+      "provider": "Cognition (Devin)",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$65,000 in credits and grants, direct support, free swag"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://devin.ai/startups",
+      "official_url": "https://devin.ai/startups",
+      "source_urls": [
+        "https://devin.ai/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "digitalocean-hatch",
+      "name": "DigitalOcean Hatch",
+      "provider": "DigitalOcean",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $100,000 in cloud credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.digitalocean.com/startups",
+      "official_url": "https://www.digitalocean.com/startups",
+      "source_urls": [
+        "https://www.digitalocean.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "google-cloud-ai-startup-program",
+      "name": "Google Cloud AI Startup Program",
+      "provider": "Google",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "AI startup credits (up to $350k)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://cloud.google.com/startup/ai",
+      "official_url": "https://cloud.google.com/startup/ai",
+      "source_urls": [
+        "https://cloud.google.com/startup/ai"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "google-cloud-startup-program",
+      "name": "Google Cloud Startup Program",
+      "provider": "Google",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Cloud credits and support"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://cloud.google.com/startup",
+      "official_url": "https://cloud.google.com/startup",
+      "source_urls": [
+        "https://cloud.google.com/startup"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "kiro-for-startups",
+      "name": "Kiro for Startups",
+      "provider": "Kiro (AWS)",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to 1 year of Kiro Pro+ credits (early stage to Series A; not stackable with active AWS Activate)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://kiro.dev/startups/",
+      "official_url": "https://kiro.dev/startups/",
+      "source_urls": [
+        "https://kiro.dev/startups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "microsoft-for-startups",
+      "name": "Microsoft for Startups",
+      "provider": "Microsoft",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Azure credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.microsoft.com/startups",
+      "official_url": "https://www.microsoft.com/startups",
+      "source_urls": [
+        "https://www.microsoft.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "miro-for-startups",
+      "name": "Miro for Startups",
+      "provider": "Miro",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$500–$1,000 in credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://miro.com/startups/",
+      "official_url": "https://miro.com/startups/",
+      "source_urls": [
+        "https://miro.com/startups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "mixpanel",
+      "name": "Mixpanel",
+      "provider": "Mixpanel",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "First year of Mixpanel free"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://mixpanel.com/startups-apply/",
+      "official_url": "https://mixpanel.com/startups-apply/",
+      "source_urls": [
+        "https://mixpanel.com/startups-apply/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "modal",
+      "name": "Modal",
+      "provider": "Modal",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free credits and technical support"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://modal.com/startups",
+      "official_url": "https://modal.com/startups",
+      "source_urls": [
+        "https://modal.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "mongodb-for-startups",
+      "name": "MongoDB for Startups",
+      "provider": "MongoDB",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Atlas credits and technical advisors"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.mongodb.com/solutions/startups",
+      "official_url": "https://www.mongodb.com/solutions/startups",
+      "source_urls": [
+        "https://www.mongodb.com/solutions/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "nebius-for-startups",
+      "name": "Nebius for Startups",
+      "provider": "Nebius",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$5,000 AI credits + discounts on GPU compute"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://nebius.com/startups",
+      "official_url": "https://nebius.com/startups",
+      "source_urls": [
+        "https://nebius.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "notion-for-startups",
+      "name": "Notion for Startups",
+      "provider": "Notion",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Business plan free for up to 6 months (incl. Notion AI)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.notion.com/startups",
+      "official_url": "https://www.notion.com/startups",
+      "source_urls": [
+        "https://www.notion.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "nvidia-inception",
+      "name": "NVIDIA Inception",
+      "provider": "NVIDIA",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free program: partner cloud credits, training, preferred GPU/software pricing"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.nvidia.com/en-us/startups/",
+      "official_url": "https://www.nvidia.com/en-us/startups/",
+      "source_urls": [
+        "https://www.nvidia.com/en-us/startups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "ovhcloud-startup-program",
+      "name": "OVHcloud Startup Program",
+      "provider": "OVHcloud",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "€10,000 for Start level; up to €100,000 for Scale level, plus technical support"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://startup.ovhcloud.com/",
+      "official_url": "https://startup.ovhcloud.com/",
+      "source_urls": [
+        "https://startup.ovhcloud.com/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "planetscale-for-startups",
+      "name": "PlanetScale for Startups",
+      "provider": "PlanetScale",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Serverless MySQL database credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://planetscale.com/startups",
+      "official_url": "https://planetscale.com/startups",
+      "source_urls": [
+        "https://planetscale.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "posthog-for-startups",
+      "name": "PostHog for Startups",
+      "provider": "PostHog",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Product analytics credits (up to ~$50k)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://posthog.com/startups",
+      "official_url": "https://posthog.com/startups",
+      "source_urls": [
+        "https://posthog.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "render",
+      "name": "Render",
+      "provider": "Render",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $100,000 in credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://render.com/startups",
+      "official_url": "https://render.com/startups",
+      "source_urls": [
+        "https://render.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "retool-for-startups",
+      "name": "Retool for Startups",
+      "provider": "Retool",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free Retool access for early-stage startups"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://retool.com/startups",
+      "official_url": "https://retool.com/startups",
+      "source_urls": [
+        "https://retool.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "sentry-for-startups",
+      "name": "Sentry for Startups",
+      "provider": "Sentry",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $5,000 in credits and priority support"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://sentry.io/for/startups/",
+      "official_url": "https://sentry.io/for/startups/",
+      "source_urls": [
+        "https://sentry.io/for/startups/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "stripe-atlas",
+      "name": "Stripe Atlas",
+      "provider": "Stripe",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Company formation and partner perks"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://stripe.com/atlas",
+      "official_url": "https://stripe.com/atlas",
+      "source_urls": [
+        "https://stripe.com/atlas"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "temporal-cloud-for-startups",
+      "name": "Temporal Cloud for Startups",
+      "provider": "Temporal",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "$6,000 Temporal Cloud credits (funded startups, $30M or less raised)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://temporal.io/startup",
+      "official_url": "https://temporal.io/startup",
+      "source_urls": [
+        "https://temporal.io/startup"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "vercel-startups",
+      "name": "Vercel Startups",
+      "provider": "Vercel",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Hosting credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://vercel.com/startups",
+      "official_url": "https://vercel.com/startups",
+      "source_urls": [
+        "https://vercel.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "y-combinator",
+      "name": "Y Combinator",
+      "provider": "Y Combinator",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Selective accelerator with funding and partner credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.ycombinator.com/apply",
+      "official_url": "https://www.ycombinator.com/apply",
+      "source_urls": [
+        "https://www.ycombinator.com/apply"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "zai-startups",
+      "name": "ZAI Startups",
+      "provider": "Z.AI",
+      "categories": [
+        "startups"
+      ],
+      "program_type": [
+        "startup_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Free API credits for Z.AI models"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://startup.z.ai/",
+      "official_url": "https://startup.z.ai/",
+      "source_urls": [
+        "https://startup.z.ai/"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "anthropic-startup-program",
+      "name": "Anthropic Startup Program",
+      "provider": "Anthropic",
+      "categories": [
+        "ai_developer_credits"
+      ],
+      "program_type": [
+        "developer_credits"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Claude API credits and priority rate limits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://claude.com/programs/startups",
+      "official_url": "https://claude.com/programs/startups",
+      "source_urls": [
+        "https://claude.com/programs/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "hugging-face-startups",
+      "name": "Hugging Face Startups",
+      "provider": "Hugging Face",
+      "categories": [
+        "ai_developer_credits"
+      ],
+      "program_type": [
+        "developer_credits"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "AI infrastructure support"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://huggingface.co/startups",
+      "official_url": "https://huggingface.co/startups",
+      "source_urls": [
+        "https://huggingface.co/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "openai-startup-program",
+      "name": "OpenAI Startup Program",
+      "provider": "OpenAI",
+      "categories": [
+        "ai_developer_credits"
+      ],
+      "program_type": [
+        "developer_credits"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "API credits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://openai.com/startups",
+      "official_url": "https://openai.com/startups",
+      "source_urls": [
+        "https://openai.com/startups"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "together-ai-research-credits-program",
+      "name": "Together AI Research Credits Program",
+      "provider": "Together AI",
+      "categories": [
+        "ai_developer_credits"
+      ],
+      "program_type": [
+        "developer_credits"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Research credits for AI projects"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.together.ai/research-credits-program-request",
+      "official_url": "https://www.together.ai/research-credits-program-request",
+      "source_urls": [
+        "https://www.together.ai/research-credits-program-request"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "together-ai-startup-accelerator",
+      "name": "Together AI Startup Accelerator",
+      "provider": "Together AI",
+      "categories": [
+        "ai_developer_credits"
+      ],
+      "program_type": [
+        "developer_credits"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Up to $50k in credits (funding-gated)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.together.ai/startup-accelerator",
+      "official_url": "https://www.together.ai/startup-accelerator",
+      "source_urls": [
+        "https://www.together.ai/startup-accelerator"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "claude-campus-ambassadors",
+      "name": "Claude Campus Ambassadors",
+      "provider": "Anthropic",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Campus club lead; USD 3,600 stipend (18+)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://claude.com/programs/campus",
+      "official_url": "https://claude.com/programs/campus",
+      "source_urls": [
+        "https://claude.com/programs/campus"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "claude-community-ambassadors",
+      "name": "Claude Community Ambassadors",
+      "provider": "Anthropic",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "API credits, event support"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://claude.com/community/ambassadors",
+      "official_url": "https://claude.com/community/ambassadors",
+      "source_urls": [
+        "https://claude.com/community/ambassadors"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "cursor-campus-leads",
+      "name": "Cursor Campus Leads",
+      "provider": "Cursor",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "6 months Cursor Ultra and event funding (applications reopen January)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://cursor.com/campus-leads",
+      "official_url": "https://cursor.com/campus-leads",
+      "source_urls": [
+        "https://cursor.com/campus-leads"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "devin-ambassadors",
+      "name": "Devin Ambassadors",
+      "provider": "Cognition (Devin)",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Community benefits"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://devin.ai/community",
+      "official_url": "https://devin.ai/community",
+      "source_urls": [
+        "https://devin.ai/community"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "kimi-ambassadors",
+      "name": "Kimi Ambassadors",
+      "provider": "Kimi",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Credits and early access"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://www.kimi.ai/lp/kimi-ambassador",
+      "official_url": "https://www.kimi.ai/lp/kimi-ambassador",
+      "source_urls": [
+        "https://www.kimi.ai/lp/kimi-ambassador"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "mistral-ai-ambassadors",
+      "name": "Mistral AI Ambassadors",
+      "provider": "Mistral",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "Studio API credits, early access"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://docs.mistral.ai/community/ambassadors",
+      "official_url": "https://docs.mistral.ai/community/ambassadors",
+      "source_urls": [
+        "https://docs.mistral.ai/community/ambassadors"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    },
+    {
+      "slug": "qwen-ambassadors",
+      "name": "Qwen Ambassadors",
+      "provider": "Alibaba Qwen",
+      "categories": [
+        "ambassadors"
+      ],
+      "program_type": [
+        "ambassador_program"
+      ],
+      "benefits": [
+        {
+          "type": "unspecified",
+          "label": "API credits ($50–$100/month)"
+        }
+      ],
+      "eligibility": {
+        "stages": [],
+        "regions": [],
+        "requirements": []
+      },
+      "status": "needs_review",
+      "application_state": "unknown",
+      "deadline": null,
+      "application_url": "https://qwen.ai/ambassador",
+      "official_url": "https://qwen.ai/ambassador",
+      "source_urls": [
+        "https://qwen.ai/ambassador"
+      ],
+      "separate_application": null,
+      "referral_only": null,
+      "last_verified_at": null,
+      "verification_method": "readme_import",
+      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+    }
+  ]
+}

--- a/data/programs.json
+++ b/data/programs.json
@@ -14,17 +14,30 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$100 in Codex credits (US & Canada students only)"
+          "type": "credits",
+          "label": "$100 Codex credits for verified university students in the US and Canada",
+          "value": 100,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "student"
+        ],
+        "regions": [
+          "US",
+          "Canada"
+        ],
+        "requirements": [
+          "Currently enrolled at a degree-granting university",
+          "Reside in the US or Canada",
+          "Verify student status with SheerID",
+          "One offer per student"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://chatgpt.com/codex/students",
       "official_url": "https://chatgpt.com/codex/students",
@@ -33,9 +46,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official page checked 2026-09-10: claim flow is available; offer is for verified current degree students in the US/Canada, one offer per student, and credits expire 12 months after grant."
     },
     {
       "slug": "figma-for-education",
@@ -49,17 +62,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Free design tools for students"
+          "type": "software_access",
+          "label": "Figma and FigJam are free for students and teachers after education verification"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "educator"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Use a student or teacher email to sign up",
+          "Verify student or educator status",
+          "Create or join an education team"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.figma.com/education/",
       "official_url": "https://www.figma.com/education/",
@@ -68,9 +88,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official page checked 2026-09-10: Figma says Figma and FigJam are free for students/teachers and provides sign-up and education-verification steps."
     },
     {
       "slug": "github-student-developer-pack",
@@ -84,17 +104,21 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Developer tools bundle (~$10k value)"
+          "type": "bundle",
+          "label": "GitHub Student Developer Pack with partner tools, including GitHub Copilot Student"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Verify student status with GitHub Education"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://education.github.com/pack",
       "official_url": "https://education.github.com/pack",
@@ -103,9 +127,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official GitHub Education page checked 2026-09-10: Student Developer Pack has a sign-up link and lists offers for verified students, including GitHub Copilot Student."
     },
     {
       "slug": "gitlab-for-education",
@@ -119,16 +143,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Free GitLab Ultimate for education"
+          "type": "software_access",
+          "label": "GitLab for Education platform for students, faculty, and educational institutions"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "student",
+          "educator",
+          "institution"
+        ],
+        "regions": [
+          "65 countries (official page)"
+        ],
+        "requirements": [
+          "Use an eligible educational institution, administrator, or educator pathway",
+          "Confirm plan entitlements with GitLab Education"
+        ]
       },
-      "status": "needs_review",
+      "status": "active",
       "application_state": "unknown",
       "deadline": null,
       "application_url": "https://about.gitlab.com/solutions/education/",
@@ -138,9 +171,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official education page checked 2026-09-10: program lists 1,000+ institutions in 65 countries and student, faculty, administrator, and IT pathways; exact plan entitlements vary by institution."
     },
     {
       "slug": "google-ai-pro-for-students",
@@ -155,7 +188,7 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "1 year of Google AI Pro (US) or AI Plus (many other countries); claim window through end of 2026"
+          "label": "Public offer terms not re-confirmed; official link redirects to Google Accounts sign-in"
         }
       ],
       "eligibility": {
@@ -173,9 +206,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official link checked 2026-09-10 but redirects to Google Accounts sign-in; public benefit, eligibility, and current claim window could not be independently verified."
     },
     {
       "slug": "google-summer-of-code",
@@ -189,14 +222,19 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Stipend and mentorship for students contributing to OSS"
+          "type": "stipend",
+          "label": "Mentored open-source contribution program; stipend and dates vary by annual cycle"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "early-career"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply to a listed open-source organization during the annual cycle"
+        ]
       },
       "status": "needs_review",
       "application_state": "unknown",
@@ -208,9 +246,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official homepage checked 2026-09-10: program and how-to-apply materials are present, but no current 2026 application dates or stipend terms were exposed in the public page snapshot."
     },
     {
       "slug": "jetbrains-student-pack",
@@ -225,11 +263,13 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "Free IDE licenses"
+          "label": "Student Pack terms not re-confirmed on the public page snapshot"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -243,9 +283,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but returned no readable program terms; current student-pack availability requires manual review."
     },
     {
       "slug": "kiro-for-students",
@@ -259,17 +299,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "1,000 credits/month free for 1 year (participating universities; SheerID verification)"
+          "type": "credits",
+          "label": "1,000 Kiro credits per month free for one year",
+          "value": 1000,
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be an eligible university student",
+          "Use a university email address",
+          "Verify through Kiro student flow"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://kiro.dev/students/",
       "official_url": "https://kiro.dev/students/",
@@ -278,9 +326,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Kiro Students page checked 2026-09-10: eligible university students receive 1,000 credits/month free for one year; page includes sign-up/verification and an eligible-school list."
     },
     {
       "slug": "lfx-mentorship",
@@ -295,11 +343,14 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "Paid remote OSS mentorship (stipends vary by region)"
+          "label": "Mentorship terms and stipend not re-confirmed on the public page snapshot"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "early-career"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -313,9 +364,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but no readable public content was returned; current mentorship rounds and stipends require manual review."
     },
     {
       "slug": "manus-campus-for-students",
@@ -329,17 +380,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Campus access; 1,000-credit referral reward per invited student"
+          "type": "credits",
+          "label": "Manus campus access after edu-email verification plus 1,000 credits per invited student",
+          "value": 1000,
+          "duration": "per referral"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "recent_graduate",
+          "educator"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Attend an eligible school",
+          "Verify a university email address",
+          "Use the school eligibility checker"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://manus.im/edu",
       "official_url": "https://manus.im/edu",
@@ -348,9 +409,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Manus Campus page checked 2026-09-10: a first batch of eligible schools is available; edu-email verification gives access and invite rewards are 1,000 credits per fellow student."
     },
     {
       "slug": "microsoft-azure-for-students",
@@ -364,17 +425,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Azure credits and dev tools"
+          "type": "credits",
+          "label": "$100 Azure credit plus free monthly amounts for 20+ services for 12 months",
+          "value": 100,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a full-time university student",
+          "Use a school email address",
+          "New Azure customer for the 12-month service amounts",
+          "No credit card required"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://azure.microsoft.com/en-us/free/students/",
       "official_url": "https://azure.microsoft.com/en-us/free/students/",
@@ -383,9 +454,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Azure page checked 2026-09-10: full-time university students can start free with a school email; offer includes $100 credit, 12-month service amounts, and annual renewal while enrolled."
     },
     {
       "slug": "mlh-fellowship",
@@ -399,17 +470,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "12-week remote fellowship with stipend"
+          "type": "stipend",
+          "label": "12-week remote open-source fellowship with an educational stipend",
+          "value": "varies",
+          "duration": "12 weeks"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "early-career"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply for an upcoming start date",
+          "Participate remotely in mentor-guided open-source projects"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://fellowship.mlh.com/",
       "official_url": "https://fellowship.mlh.com/",
@@ -418,9 +497,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official MLH Fellowship page checked 2026-09-10: 12-week remote program, educational stipend, and an Apply Now link for upcoming start dates."
     },
     {
       "slug": "openai-student-collective",
@@ -434,18 +513,35 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Campus Lead role: ChatGPT + Codex credits, event funding, and stipend"
+          "type": "student_program",
+          "label": "Campus Lead program: ChatGPT subscription, Codex credits, event funding, training, merch, and cash stipend"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "student"
+        ],
+        "regions": [
+          "US",
+          "Canada",
+          "UK",
+          "France",
+          "Germany",
+          "India",
+          "Japan",
+          "South Korea"
+        ],
+        "requirements": [
+          "Be 18 or older",
+          "Be enrolled in an undergraduate program as of August 2026",
+          "Expect to graduate after December 2027",
+          "Commit 4–6 hours/week from August 2026 to June 2027",
+          "Have work authorization in the country of study"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
+      "status": "paused",
+      "application_state": "closed",
+      "deadline": "2026-08-31",
       "application_url": "https://openai.com/student-collective/",
       "official_url": "https://openai.com/student-collective/",
       "source_urls": [
@@ -453,9 +549,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official OpenAI Student Collective page checked 2026-09-10: Fall 2026 applications are closed in the US, Canada, and India; applications for Japan, Korea, the UK, Germany, and France closed August 31, 2026. Future-interest submissions remain available."
     },
     {
       "slug": "outreachy",
@@ -469,17 +565,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Paid remote OSS internship (~$7,000 stipend)"
+          "type": "stipend",
+          "label": "Paid remote open-source internship; stipend amount varies by cohort and location"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "early-career"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply during a published Outreachy application window",
+          "Complete the contribution period",
+          "Meet the cohort eligibility requirements"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "paused",
+      "application_state": "closed",
       "deadline": null,
       "application_url": "https://www.outreachy.org/",
       "official_url": "https://www.outreachy.org/",
@@ -488,9 +591,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Outreachy page checked 2026-09-10: May 2026 applications are closed and the December 2026 application window was early-to-mid August; page provides an applicant guide and mailing list for future cycles."
     },
     {
       "slug": "v0-for-students",
@@ -504,17 +607,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "1 year of free v0 Premium (limited partner universities)"
+          "type": "subscription",
+          "label": "One year of free v0 Premium after student verification",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Verify student status with an active school",
+          "Use the student-email join flow",
+          "Attend one of the listed active schools"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://v0.app/students",
       "official_url": "https://v0.app/students",
@@ -523,9 +633,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official v0 Students page checked 2026-09-10: one year of free v0 Premium is offered after student verification and the page lists active qualifying schools with a join button."
     },
     {
       "slug": "yc-ai-student-starter-pack",
@@ -539,17 +649,26 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Credits and tools (~$25k value; requires attending a YC student event)"
+          "type": "credits",
+          "label": "Over $25,000 in credits for AI tools and cloud services",
+          "value": 25000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Attend a YC university event starting in Fall 2025",
+          "Use the same Hacker News account used to RSVP",
+          "Sign in to check eligibility"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "invite_only",
       "deadline": null,
       "application_url": "https://deals.ycombinator.com/students",
       "official_url": "https://deals.ycombinator.com/students",
@@ -558,9 +677,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official YC Deals page checked 2026-09-10: YC AI Stack lists $25k+ in credits, event attendance eligibility, one-year access, and an authenticated eligibility check."
     },
     {
       "slug": "zed-student-plan",
@@ -574,17 +693,28 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "All Zed Pro features for 12 months"
+          "type": "subscription",
+          "label": "Zed Pro features plus $10/month AI token credits for one year",
+          "value": 10,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "student"
+        ],
+        "regions": [
+          "worldwide"
+        ],
+        "requirements": [
+          "Be enrolled at an accredited university",
+          "Verify enrollment",
+          "Use a GitHub account older than 30 days and a current university email"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://zed.dev/education",
       "official_url": "https://zed.dev/education",
@@ -593,9 +723,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Zed Education page checked 2026-09-10: accredited university students worldwide can verify enrollment; one-year Student Plan includes Pro features and $10/month in AI token credits."
     },
     {
       "slug": "atlas-cloud-for-open-source",
@@ -610,11 +740,14 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "Up to $1,500/mo AI credits (400+ models) for active OSS maintainers"
+          "label": "OSS program offer not re-confirmed; official URL redirects to the Atlas Cloud homepage"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer",
+          "contributor"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -628,9 +761,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official OSS URL checked 2026-09-10 and redirected to the general Atlas Cloud homepage; the claimed OSS credit amount and application flow could not be independently verified."
     },
     {
       "slug": "capy-ai-oss",
@@ -644,17 +777,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Full platform access for open-source projects"
+          "type": "software_access",
+          "label": "Full Capy platform access free while the project remains open source"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer",
+          "contributor"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Maintain a public GitHub project with an OSI-approved license",
+          "Have active community development",
+          "Apply as an owner or maintainer"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://capy.ai/open-source",
       "official_url": "https://capy.ai/open-source",
@@ -663,9 +803,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Capy page checked 2026-09-10: applications are open; maintainers get full platform access free while the project remains open source."
     },
     {
       "slug": "catalyst",
@@ -679,17 +819,29 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$10,000 sponsorship + 3-month program for eligible OSS authors and maintainers"
+          "type": "funding",
+          "label": "$10,000 sponsorship plus funding and mentorship for an open-source project",
+          "value": 10000,
+          "currency": "USD",
+          "duration": "program term"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "maintainer",
+          "founder"
+        ],
+        "regions": [
+          "remote"
+        ],
+        "requirements": [
+          "Build an open-source project",
+          "Apply through the Catalyst application",
+          "Participate in weekly OCV office hours"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://opencoreventures.com/catalyst/",
       "official_url": "https://opencoreventures.com/catalyst/",
@@ -698,9 +850,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Open Core Ventures page checked 2026-09-10: Catalyst offers $10k, mentorship, and a remote program; the page links an application for Summer 2026."
     },
     {
       "slug": "claude-for-open-source",
@@ -714,17 +866,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "6 months of Claude Max"
+          "type": "subscription",
+          "label": "Six months of free Claude Max 20x"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer",
+          "contributor"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Contribute to an open-source project",
+          "Apply through the Claude for Open Source form"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://claude.com/contact-sales/claude-for-oss",
       "official_url": "https://claude.com/contact-sales/claude-for-oss",
@@ -733,9 +891,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Claude for Open Source page checked 2026-09-10: it explicitly offers six months of free Claude Max 20x to open-source contributors and has an Apply now flow."
     },
     {
       "slug": "github-secure-open-source-fund",
@@ -749,17 +907,31 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$10,000 project funding, $10,000 Azure credits, Copilot Pro, and a 3-week security program"
+          "type": "funding",
+          "label": "$10,000 per selected open-source project, paid in program tranches",
+          "value": 10000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "maintainer"
+        ],
+        "regions": [
+          "GitHub Sponsors-supported regions"
+        ],
+        "requirements": [
+          "Be a current open-source maintainer",
+          "Be 18 or older",
+          "Have an active GitHub profile",
+          "Use a clear open-source license",
+          "Have demonstrated community traction",
+          "Not be a GitHub employee"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "rolling",
       "deadline": null,
       "application_url": "https://github.com/open-source/github-secure-open-source-fund",
       "official_url": "https://github.com/open-source/github-secure-open-source-fund",
@@ -768,9 +940,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official GitHub Secure Open Source Fund page checked 2026-09-10: current maintainers can submit an application; funding is $10k per project and applications are open on a rolling basis."
     },
     {
       "slug": "microsoft-foss-fund",
@@ -784,17 +956,22 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $12,500 USD for selected projects"
+          "type": "sponsorship",
+          "label": "Sponsorship rounds for open-source projects selected through Microsoft employee and intern nominations"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be nominated by a Microsoft employee or intern",
+          "Have an open-source project"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "invite_only",
       "deadline": null,
       "application_url": "https://github.com/microsoft/foss-fund",
       "official_url": "https://github.com/microsoft/foss-fund",
@@ -802,10 +979,10 @@
         "https://github.com/microsoft/foss-fund"
       ],
       "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "referral_only": true,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Microsoft FOSS Fund repository checked 2026-09-10: the fund sponsors projects selected by Microsoft employees; nomination is open to Microsoft employees and interns, not a public self-serve application."
     },
     {
       "slug": "ona-for-open-source",
@@ -819,17 +996,26 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $200/mo AI credits for OSS maintainers and contributors"
+          "type": "credits",
+          "label": "Up to $200/month in free AI credits for open-source maintainers and contributors",
+          "value": 200,
+          "currency": "USD",
+          "duration": "monthly"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer",
+          "contributor"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Maintain or contribute to an open-source project",
+          "Apply through the program form"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://ona.com/stories/ona-for-open-source",
       "official_url": "https://ona.com/stories/ona-for-open-source",
@@ -838,9 +1024,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Ona page checked 2026-09-10: the relaunched program offers up to $200/month in free AI credits and links an application for maintainers and contributors."
     },
     {
       "slug": "openai-codex-for-open-source",
@@ -854,17 +1040,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "6 months of ChatGPT Pro with Codex, plus API credits"
+          "type": "subscription",
+          "label": "Six months of ChatGPT Pro with Codex plus conditional access to Codex Security",
+          "duration": "6 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a core maintainer or run a widely used public project",
+          "Apply through the program form",
+          "Have write access for Codex Security consideration"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://developers.openai.com/community/codex-for-oss",
       "official_url": "https://developers.openai.com/community/codex-for-oss",
@@ -873,9 +1066,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official OpenAI Developers page checked 2026-09-10: eligible maintainers can apply for six months of ChatGPT Pro with Codex and conditional Codex Security access."
     },
     {
       "slug": "snyk-for-open-source",
@@ -889,17 +1082,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Full Snyk platform free for qualifying OSS maintainers"
+          "type": "software_access",
+          "label": "Complimentary Snyk security tooling and full licenses for qualifying open-source projects"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Maintain an open-source project",
+          "Apply to join an existing project or apply for a new project",
+          "Use entitlements only for open-source projects"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://snyk.io/open-source",
       "official_url": "https://snyk.io/open-source",
@@ -908,9 +1107,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Snyk page checked 2026-09-10: open-source maintainers can apply for complimentary security tooling; full entitlements are limited to open-source projects."
     },
     {
       "slug": "upstash-for-open-source",
@@ -924,17 +1123,26 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$1,000 monthly credit grant"
+          "type": "credits",
+          "label": "$1,000 monthly credit grant and support (applications currently closed)",
+          "value": 1000,
+          "currency": "USD",
+          "duration": "monthly"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "maintainer",
+          "contributor"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Build an open-source project on Upstash",
+          "Wait for the next application window"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "paused",
+      "application_state": "closed",
       "deadline": null,
       "application_url": "https://upstash.com/open-source",
       "official_url": "https://upstash.com/open-source",
@@ -943,9 +1151,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Upstash Open Source page checked 2026-09-10: it describes credit grants and support but explicitly says applications are currently closed."
     },
     {
       "slug": "assemblyai-startup-program",
@@ -959,17 +1167,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "12 months free credits for voice/speech AI"
+          "type": "credits",
+          "label": "12 months of recurring free credits plus discounted startup pricing",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-seed",
+          "seed",
+          "series_a"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be an early-stage or bootstrapped startup",
+          "Build a product with voice or audio at its core",
+          "Launch within six months",
+          "Apply with a work email"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.assemblyai.com/contact/startup-program",
       "official_url": "https://www.assemblyai.com/contact/startup-program",
@@ -978,9 +1196,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official AssemblyAI startup page checked 2026-09-10: pre-seed to Series A and bootstrapped teams are eligible; the page offers 12 months of recurring free credits and a live application form."
     },
     {
       "slug": "aws-activate",
@@ -994,17 +1212,29 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Cloud credits (up to $100k)"
+          "type": "credits",
+          "label": "Up to $200,000 in AWS Activate credits, with $200,000+ AI credits available by invitation",
+          "value": 200000,
+          "currency": "USD",
+          "duration": "program terms"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-seed",
+          "seed",
+          "series_a",
+          "series_b"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be founded within the last 10 years",
+          "Use a paid AWS account",
+          "Apply directly if self-funded or use an Activate Provider Org ID for Portfolio credits"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://aws.amazon.com/startups/credits",
       "official_url": "https://aws.amazon.com/startups/credits",
@@ -1013,9 +1243,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official AWS Activate page checked 2026-09-10: Founders credits start at $1k and can reach $5k; Portfolio credits can reach $200k, while additional AI credits are invite-only."
     },
     {
       "slug": "circleci-for-startups",
@@ -1029,17 +1259,28 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $20,000 in compute credits"
+          "type": "credits",
+          "label": "Up to $20,000 in compute credits plus up to 24 months free and Starter Support",
+          "value": 20000,
+          "currency": "USD",
+          "duration": "up to 24 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-seed",
+          "seed",
+          "series_a"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be new to CircleCI or on the Free plan",
+          "Be founded within the last five years",
+          "Be part of an accelerator/VC or show at least $500k raised"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://circleci.com/startup-program/",
       "official_url": "https://circleci.com/startup-program/",
@@ -1048,9 +1289,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official CircleCI page checked 2026-09-10: offer lists up to $20k compute credits, up to 24 months free, and a live Apply today flow with stage/location-dependent terms."
     },
     {
       "slug": "clerk-for-startups",
@@ -1064,17 +1305,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Clerk Pro at a discount for early-stage startups"
+          "type": "discount",
+          "label": "Clerk Pro features at a startup discount for up to one year after launch"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "early-stage"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be within one year of launch",
+          "Have raised no more than $5M in venture funding",
+          "Apply as a new startup customer"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://clerk.com/startups",
       "official_url": "https://clerk.com/startups",
@@ -1083,9 +1330,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Clerk page checked 2026-09-10: eligible early-stage teams can apply for discounted Clerk Pro; eligibility is up to one year after launch and up to $5M venture funding."
     },
     {
       "slug": "cloudflare-for-startups",
@@ -1099,17 +1346,30 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $350,000 in Cloudflare credits"
+          "type": "credits",
+          "label": "Up to $350,000 in Cloudflare credits for one year",
+          "value": 350000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-seed",
+          "seed",
+          "series_a",
+          "series_b"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be incorporated within the last 10 years",
+          "Be funded up to Series B and within the last 12 months",
+          "Build a technology product",
+          "Have a public website and social presence"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.cloudflare.com/forstartups/",
       "official_url": "https://www.cloudflare.com/forstartups/",
@@ -1118,9 +1378,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Cloudflare Startups page checked 2026-09-10: program offers up to $350k for one year, with a $10k bootstrapped tier and a public Apply now flow."
     },
     {
       "slug": "databricks-startup-program",
@@ -1134,17 +1394,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $200k in credits across Databricks and Neon"
+          "type": "credits",
+          "label": "Up to $200,000 in credits for Databricks and Neon",
+          "value": 200000,
+          "currency": "USD"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a qualifying startup",
+          "Apply directly or ask an investor for access"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.databricks.com/product/startups",
       "official_url": "https://www.databricks.com/product/startups",
@@ -1153,9 +1420,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Databricks page checked 2026-09-10: qualifying startups can receive up to $200k in Databricks and Neon credits and the page links Apply now."
     },
     {
       "slug": "datadog-for-startups",
@@ -1169,17 +1436,28 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "A year of free Datadog Pro"
+          "type": "credits",
+          "label": "Up to one year of free Datadog platform access, up to $100,000 in credits",
+          "value": 100000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-seed",
+          "seed",
+          "series_a"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be new to Datadog",
+          "Be Series A or earlier",
+          "Apply through an official referral partner"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "invite_only",
       "deadline": null,
       "application_url": "https://www.datadoghq.com/partner/datadog-for-startups/",
       "official_url": "https://www.datadoghq.com/partner/datadog-for-startups/",
@@ -1187,10 +1465,10 @@
         "https://www.datadoghq.com/partner/datadog-for-startups/"
       ],
       "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "referral_only": true,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Datadog page checked 2026-09-10: Series A-or-earlier startups can receive up to one year/free platform access up to $100k, but every applicant must come through a referral partner."
     },
     {
       "slug": "daytona",
@@ -1204,17 +1482,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $50k in Daytona credits"
+          "type": "credits",
+          "label": "$10,000 immediately and up to $100,000 in Daytona credits",
+          "value": 100000,
+          "currency": "USD"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Submit the startup form with company, website, and location details"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.daytona.io/startups",
       "official_url": "https://www.daytona.io/startups",
@@ -1223,9 +1507,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Daytona page checked 2026-09-10: page advertises $10k immediately and up to $100k in credits with a live startup form."
     },
     {
       "slug": "deepgram-for-startups",
@@ -1239,17 +1523,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $100,000 in voice AI credits"
+          "type": "credits",
+          "label": "Up to $100,000 in Deepgram credits over 12 months",
+          "value": 100000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "early-stage",
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be an AI builder or early-stage startup",
+          "Be in production or launching within six months",
+          "Actively build and engage with the community"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://deepgram.com/startup-program",
       "official_url": "https://deepgram.com/startup-program",
@@ -1258,9 +1552,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Deepgram page checked 2026-09-10: up to $100k in credits over 12 months, explicit eligibility criteria, and an Apply Now flow are visible."
     },
     {
       "slug": "devin-for-startups",
@@ -1274,17 +1568,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$65,000 in credits and grants, direct support, free swag"
+          "type": "credits",
+          "label": "$15,000 Devin credits plus up to $50,000 in matching grants",
+          "value": 65000,
+          "currency": "USD",
+          "duration": "program terms"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Submit a startup application",
+          "Be approved on the rolling review process"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "rolling",
       "deadline": null,
       "application_url": "https://devin.ai/startups",
       "official_url": "https://devin.ai/startups",
@@ -1293,9 +1595,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Devin page checked 2026-09-10: accepted startups get $15k free credits, up to $50k matching grants, unlimited seats, and rolling applications."
     },
     {
       "slug": "digitalocean-hatch",
@@ -1309,17 +1611,22 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $100,000 in cloud credits"
+          "type": "credits",
+          "label": "DigitalOcean startup credits and invited GPU credit packages"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply through the DigitalOcean Startups form",
+          "Be selected for any GPU credit package"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.digitalocean.com/startups",
       "official_url": "https://www.digitalocean.com/startups",
@@ -1328,9 +1635,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official DigitalOcean Startups page checked 2026-09-10: it has a live application form, AI-platform credits, and says selected startups may apply for GPU credit packages; no fixed total was publicly stated."
     },
     {
       "slug": "google-cloud-ai-startup-program",
@@ -1344,17 +1651,28 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "AI startup credits (up to $350k)"
+          "type": "credits",
+          "label": "Up to $350,000 in Google Cloud credits for AI-first startups over two years",
+          "value": 350000,
+          "currency": "USD",
+          "duration": "24 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-seed",
+          "seed",
+          "series_a"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a qualifying AI-first startup",
+          "Apply through Google for Startups Cloud Program",
+          "Use credits for covered Google Cloud services/models"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://cloud.google.com/startup/ai",
       "official_url": "https://cloud.google.com/startup/ai",
@@ -1363,9 +1681,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Google Cloud AI startup page checked 2026-09-10: AI-first startups can receive up to $350k over two years and the page links Apply here."
     },
     {
       "slug": "google-cloud-startup-program",
@@ -1379,17 +1697,28 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Cloud credits and support"
+          "type": "credits",
+          "label": "Up to $200,000 in Google Cloud credits, or up to $350,000 for AI-first startups",
+          "value": 350000,
+          "currency": "USD",
+          "duration": "24 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "pre-funded",
+          "seed",
+          "series_a",
+          "series_b"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply through Google for Startups Cloud Program",
+          "Match the appropriate pre-funded, early-stage, or Series B+ path"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://cloud.google.com/startup",
       "official_url": "https://cloud.google.com/startup",
@@ -1398,9 +1727,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Google Cloud Startups page checked 2026-09-10: early-stage teams can apply for up to $200k (up to $350k for AI-first startups), while pre-funded teams can apply for $2k MVP credits."
     },
     {
       "slug": "kiro-for-startups",
@@ -1414,17 +1743,28 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to 1 year of Kiro Pro+ credits (early stage to Series A; not stackable with active AWS Activate)"
+          "type": "credits",
+          "label": "Up to one year of Kiro Pro+ credits for early-stage to Series A startups",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "early-stage",
+          "series_a"
+        ],
+        "regions": [
+          "most AWS-billed countries/regions"
+        ],
+        "requirements": [
+          "Be VC-backed",
+          "Use a matching business email and AWS Account ID",
+          "Use AWS IAM Identity Center to redeem",
+          "Not have active AWS Activate credits for this promotion"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "rolling",
       "deadline": null,
       "application_url": "https://kiro.dev/startups/",
       "official_url": "https://kiro.dev/startups/",
@@ -1433,9 +1773,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Kiro Startups page checked 2026-09-10: early-stage to Series A VC-backed startups globally can apply for up to one year of Pro+ credits; applications are reviewed on a rolling basis."
     },
     {
       "slug": "microsoft-for-startups",
@@ -1449,17 +1789,22 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Azure credits"
+          "type": "credits",
+          "label": "Free Azure credits plus AI tools, expert guidance, and startup resources"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Sign up through Microsoft for Startups",
+          "Use an investor referral code or start building with Azure"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.microsoft.com/startups",
       "official_url": "https://www.microsoft.com/startups",
@@ -1468,9 +1813,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Microsoft for Startups page checked 2026-09-10: program offers free Azure credits and AI tools, with sign-up available via an investor referral code or direct Azure onboarding."
     },
     {
       "slug": "miro-for-startups",
@@ -1484,17 +1829,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$500–$1,000 in credits"
+          "type": "credits",
+          "label": "Free Miro credits for early startups; up to 25% discount for scale-ups"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "early-stage",
+          "scale-up"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply through Miro startup offer flow",
+          "Use the applicable early-startup or scale-up path"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://miro.com/startups/",
       "official_url": "https://miro.com/startups/",
@@ -1503,9 +1854,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Miro Startups page checked 2026-09-10: early startups can get free Miro credits, scale-ups up to 25% discount, and the page links both offer flows."
     },
     {
       "slug": "mixpanel",
@@ -1520,11 +1871,13 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "First year of Mixpanel free"
+          "label": "Startup offer could not be re-confirmed; public URL returned only an embedded form shell"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -1538,9 +1891,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but the page exposed only an iframe shell with no readable offer terms; current Mixpanel startup benefit requires manual review."
     },
     {
       "slug": "modal",
@@ -1554,17 +1907,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Free credits and technical support"
+          "type": "credits",
+          "label": "Thousands of free GPU credits plus technical and go-to-market support"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "seed",
+          "series_a",
+          "series_b"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be new to Modal",
+          "Seed to Series A: have VC partner funding or >$1M VC funding",
+          "Series B+: meet the stated funding/partner criteria"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://modal.com/startups",
       "official_url": "https://modal.com/startups",
@@ -1573,9 +1934,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Modal page checked 2026-09-10: applications are open; program offers free GPU credits, technical/GTM support, and publishes eligibility tiers."
     },
     {
       "slug": "mongodb-for-startups",
@@ -1589,17 +1950,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Atlas credits and technical advisors"
+          "type": "credits",
+          "label": "MongoDB Atlas credits, Voyage AI tokens, technical expertise, and support"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "bootstrapped",
+          "early-funded",
+          "vc-backed",
+          "scale-up"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply directly or ask a VC/accelerator/incubator for referral",
+          "Use the applicable startup tier"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.mongodb.com/solutions/startups",
       "official_url": "https://www.mongodb.com/solutions/startups",
@@ -1608,9 +1977,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official MongoDB Startups page checked 2026-09-10: program has a live Apply Now flow, tiered support from bootstrapped to scaling startups, and Atlas/Voyage benefits."
     },
     {
       "slug": "nebius-for-startups",
@@ -1624,17 +1993,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$5,000 AI credits + discounts on GPU compute"
+          "type": "credits",
+          "label": "Nebius startup credits and compute discounts; credit access currently through VC partners"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Have a Nebius VC partner for credit access, or join the community while availability expands",
+          "Maintain a company website and apply with a company email",
+          "Be incorporated fewer than five years"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "paused",
+      "application_state": "invite_only",
       "deadline": null,
       "application_url": "https://nebius.com/startups",
       "official_url": "https://nebius.com/startups",
@@ -1642,10 +2017,10 @@
         "https://nebius.com/startups"
       ],
       "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "referral_only": true,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Nebius page checked 2026-09-10: credits are currently available exclusively through venture-capital partners; other startups are directed to the community/waitlist as availability expands."
     },
     {
       "slug": "notion-for-startups",
@@ -1659,17 +2034,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Business plan free for up to 6 months (incl. Notion AI)"
+          "type": "subscription",
+          "label": "Notion Business with Notion AI free for 3 or 6 months depending on eligibility",
+          "duration": "3–6 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a non-paying Notion customer",
+          "Have fewer than 100 employees for the 3/6-month offers",
+          "Have a valid business website and company-domain email or a select partner affiliation"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.notion.com/startups",
       "official_url": "https://www.notion.com/startups",
@@ -1678,9 +2060,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Notion Startups page checked 2026-09-10: page lists 6 months for select partners and 3 months with business website/domain email, with a live application flow."
     },
     {
       "slug": "nvidia-inception",
@@ -1694,17 +2076,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Free program: partner cloud credits, training, preferred GPU/software pricing"
+          "type": "membership",
+          "label": "Free NVIDIA Inception membership with partner cloud credits, training, preferred pricing, and resources"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Employ at least one developer",
+          "Maintain a working website",
+          "Be officially incorporated",
+          "Be less than 10 years old",
+          "Not be a consultancy, reseller, public company, cloud provider, or crypto company"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.nvidia.com/en-us/startups/",
       "official_url": "https://www.nvidia.com/en-us/startups/",
@@ -1713,9 +2103,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official NVIDIA Inception page checked 2026-09-10: membership is free with no fees/equity; criteria include one developer, working website, incorporation, and age under 10 years."
     },
     {
       "slug": "ovhcloud-startup-program",
@@ -1729,17 +2119,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "€10,000 for Start level; up to €100,000 for Scale level, plus technical support"
+          "type": "credits",
+          "label": "Up to €100,000 in free OVHcloud credits plus one-on-one engineering consultation",
+          "value": 100000,
+          "currency": "EUR"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply through the OVHcloud Startup Program",
+          "Meet the program tier requirements"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://startup.ovhcloud.com/",
       "official_url": "https://startup.ovhcloud.com/",
@@ -1748,9 +2145,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official OVHcloud Startup Program page checked 2026-09-10: it advertises up to €100k in free cloud credit, engineering consultation, and a live Apply flow."
     },
     {
       "slug": "planetscale-for-startups",
@@ -1765,11 +2162,13 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "Serverless MySQL database credits"
+          "label": "Startup-specific credit offer not re-confirmed; page currently describes paid database plans and free sign-up"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -1783,9 +2182,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official PlanetScale page checked 2026-09-10: startup landing page is live, but no startup credit amount or dedicated offer was publicly stated; only free sign-up and paid pricing were visible."
     },
     {
       "slug": "posthog-for-startups",
@@ -1799,17 +2198,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Product analytics credits (up to ~$50k)"
+          "type": "credits",
+          "label": "$50,000 in PostHog credits plus $12,000 in partner benefits for 12 months",
+          "value": 50000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "early-stage",
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Build a self-driving product",
+          "Meet funding/age/team criteria shown on the page",
+          "Apply with a PostHog account"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://posthog.com/startups",
       "official_url": "https://posthog.com/startups",
@@ -1818,9 +2227,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official PostHog page checked 2026-09-10: it lists $50k credits for 12 months, $12k partner benefits, and a live Apply now flow."
     },
     {
       "slug": "render",
@@ -1834,17 +2243,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $100,000 in credits"
+          "type": "credits",
+          "label": "Up to $10,000 in Render migration credits",
+          "value": 10000,
+          "currency": "USD"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be migrating production infrastructure",
+          "Apply through the migration-credit form"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://render.com/startups",
       "official_url": "https://render.com/startups",
@@ -1853,9 +2269,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Render page checked 2026-09-10: current page advertises up to $10k in migration credits and a live Apply now link; the older $100k startup-credit claim was not present."
     },
     {
       "slug": "retool-for-startups",
@@ -1869,17 +2285,32 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Free Retool access for early-stage startups"
+          "type": "discount",
+          "label": "100% off Retool Team or Business for one year, up to $60,000 value, then 25% off year two",
+          "value": 60000,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "bootstrapped",
+          "angel-funded",
+          "debt-funded",
+          "pre-seed",
+          "seed",
+          "series_a"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Raise less than $10M",
+          "Be founded within the last 10 years",
+          "Be a new monthly Team or Business customer",
+          "Submit the application after upgrading"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://retool.com/startups",
       "official_url": "https://retool.com/startups",
@@ -1888,9 +2319,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Retool page checked 2026-09-10: eligible startups get one year free up to $60k, 25% off the following year, and a live application flow."
     },
     {
       "slug": "sentry-for-startups",
@@ -1905,11 +2336,13 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "Up to $5,000 in credits and priority support"
+          "label": "Startup offer could not be re-confirmed; official URL rendered only a terminal shell"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -1923,9 +2356,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but rendered only a terminal shell with no readable program terms; current Sentry offer requires manual review."
     },
     {
       "slug": "stripe-atlas",
@@ -1939,17 +2372,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Company formation and partner perks"
+          "type": "credits",
+          "label": "$2,500 Stripe product credits plus $50,000+ in partner discounts for Atlas companies",
+          "value": 2500,
+          "currency": "USD",
+          "duration": "12 months"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "founder",
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Submit company and co-founder details",
+          "Use Stripe Atlas incorporation flow",
+          "Review jurisdiction and legal requirements before proceeding"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://stripe.com/atlas",
       "official_url": "https://stripe.com/atlas",
@@ -1958,9 +2401,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Stripe Atlas page checked 2026-09-10: Atlas is live; companies receive $2,500 in Stripe product credits in the first year plus $50k+ in partner discounts."
     },
     {
       "slug": "temporal-cloud-for-startups",
@@ -1974,17 +2417,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "$6,000 Temporal Cloud credits (funded startups, $30M or less raised)"
+          "type": "credits",
+          "label": "$6,000 in Temporal Cloud credits for funded startups",
+          "value": 6000,
+          "currency": "USD"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "funded_startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a funded startup",
+          "Have raised $30M or less",
+          "Apply through the startup form"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://temporal.io/startup",
       "official_url": "https://temporal.io/startup",
@@ -1993,9 +2444,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Temporal page checked 2026-09-10: funded startups that raised $30M or less can apply for $6k in Temporal Cloud credits."
     },
     {
       "slug": "vercel-startups",
@@ -2009,17 +2460,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Hosting credits"
+          "type": "credits",
+          "label": "Up to $30,000 Flexible Commitment Amount plus Enterprise-tier access and support",
+          "value": 30000,
+          "currency": "USD"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be an eligible startup team",
+          "Contact the Vercel Startups team"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://vercel.com/startups",
       "official_url": "https://vercel.com/startups",
@@ -2028,9 +2486,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Vercel Startups page checked 2026-09-10: eligible teams can receive up to $30k Flexible Commitment Amount, Enterprise-tier access, and startup-focused support."
     },
     {
       "slug": "y-combinator",
@@ -2044,18 +2502,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Selective accelerator with funding and partner credits"
+          "type": "funding",
+          "label": "Selective accelerator application with funding and partner benefits"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup",
+          "founder"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Submit the online YC application",
+          "Meet the current batch deadline or apply late for consideration"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
+      "status": "active",
+      "application_state": "open",
+      "deadline": "2026-11-02",
       "application_url": "https://www.ycombinator.com/apply",
       "official_url": "https://www.ycombinator.com/apply",
       "source_urls": [
@@ -2063,9 +2527,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official YC application page checked 2026-09-10: online applications are open; page states an on-time November 2 deadline and says late applications may still be considered."
     },
     {
       "slug": "zai-startups",
@@ -2080,11 +2544,13 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "Free API credits for Z.AI models"
+          "label": "Startup API-credit offer could not be re-confirmed; official URL returned an internal error"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -2098,9 +2564,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but returned an internal error with no readable program terms; current Z.AI startup offer requires manual review."
     },
     {
       "slug": "anthropic-startup-program",
@@ -2114,17 +2580,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Claude API credits and priority rate limits"
+          "type": "credits",
+          "label": "Claude API credits and priority rate limits for qualifying startups"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "early-stage",
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Have an institutional equity investor for credits/extras",
+          "Be founded within the last four years",
+          "Not have previously received Anthropic startup credits",
+          "Apply with a Claude Console account, company email, website, and product description"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://claude.com/programs/startups",
       "official_url": "https://claude.com/programs/startups",
@@ -2133,9 +2607,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Claude for Startups page checked 2026-09-10: application is open; credits/extras require institutional equity funding, a company founded within four years, and no prior Anthropic startup credits."
     },
     {
       "slug": "hugging-face-startups",
@@ -2150,11 +2624,13 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "AI infrastructure support"
+          "label": "Startup program could not be re-confirmed; official URL resolves to a Hugging Face community profile without public offer terms"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -2168,9 +2644,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but resolves to a public Hugging Face profile named startupsdao with no startup-program benefits or application terms; requires manual review."
     },
     {
       "slug": "openai-startup-program",
@@ -2184,17 +2660,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "API credits"
+          "type": "credits",
+          "label": "OpenAI API credits, rate-limit upgrades, technical support, and startup events for eligible VC portfolios"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be in a participating VC partner portfolio",
+          "Obtain a unique VC referral code",
+          "Provide company/product/funding details"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "invite_only",
       "deadline": null,
       "application_url": "https://openai.com/startups",
       "official_url": "https://openai.com/startups",
@@ -2202,10 +2684,10 @@
         "https://openai.com/startups"
       ],
       "separate_application": null,
-      "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "referral_only": true,
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official OpenAI Startups page checked 2026-09-10: VC portfolio companies may unlock free API credits and rate-limit upgrades; applications require a unique referral code from a VC."
     },
     {
       "slug": "together-ai-research-credits-program",
@@ -2219,17 +2701,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Research credits for AI projects"
+          "type": "credits",
+          "label": "Small research grants of a few hundred dollars for eligible student projects",
+        "value": "few hundred",
+          "currency": "USD",
+          "duration": "grant"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student",
+          "researcher"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Have a research idea outside formal classes",
+          "Request support through the invite-only program",
+          "Acknowledge Together AI in resulting work"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "invite_only",
       "deadline": null,
       "application_url": "https://www.together.ai/research-credits-program-request",
       "official_url": "https://www.together.ai/research-credits-program-request",
@@ -2238,9 +2730,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Together AI Research Credits page checked 2026-09-10: invite-only program offers small grants to students doing research outside formal classes; page says it is not widely available."
     },
     {
       "slug": "together-ai-startup-accelerator",
@@ -2254,17 +2746,26 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Up to $50k in credits (funding-gated)"
+          "type": "credits",
+          "label": "Up to $15k/$30k/$50k in platform credits by funding tier plus engineering time",
+          "value": 50000,
+          "currency": "USD",
+          "duration": "program term"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "startup"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Submit a selection-based application",
+          "Build on Together AI",
+          "Choose tier by total funding: up to $5M, $5M–$10M, or over $10M raised"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.together.ai/startup-accelerator",
       "official_url": "https://www.together.ai/startup-accelerator",
@@ -2273,9 +2774,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Together AI Startup Accelerator page checked 2026-09-10: selection-based applications are open; tiers offer up to $15k, $30k, or $50k in credits plus forward-deployed engineering time."
     },
     {
       "slug": "claude-campus-ambassadors",
@@ -2289,18 +2790,33 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Campus club lead; USD 3,600 stipend (18+)"
+          "type": "stipend",
+          "label": "USD 3,600 cash stipend plus campus event support, resources, and API credits",
+          "value": 3600,
+          "currency": "USD",
+          "duration": "program year"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "student",
+          "graduate_student",
+          "phd",
+          "postdoc"
+        ],
+        "regions": [
+          "worldwide"
+        ],
+        "requirements": [
+          "Be 18 or older",
+          "Have work authorization in the country of study",
+          "Apply by September 12, 2026",
+          "Choose the undergrad, grad, or PhD/postdoc track"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
-      "deadline": null,
+      "status": "active",
+      "application_state": "open",
+      "deadline": "2026-09-12",
       "application_url": "https://claude.com/programs/campus",
       "official_url": "https://claude.com/programs/campus",
       "source_urls": [
@@ -2308,9 +2824,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Claude Campus page checked 2026-09-10: applications are open and close September 12, 2026; selected ambassadors receive a $3,600 stipend and the program runs September 2026–June 2027."
     },
     {
       "slug": "claude-community-ambassadors",
@@ -2324,17 +2840,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "API credits, event support"
+          "type": "community",
+          "label": "Event sponsorship, API credits, swag, resources, and product feedback access"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "community_builder",
+          "developer",
+          "organizer"
+        ],
+        "regions": [
+          "worldwide"
+        ],
+        "requirements": [
+          "Have meaningful Claude Code or Claude Cowork experience",
+          "Have a track record of community involvement",
+          "Apply and complete the screening process"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://claude.com/community/ambassadors",
       "official_url": "https://claude.com/community/ambassadors",
@@ -2343,9 +2869,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Claude Community Ambassadors page checked 2026-09-10: global applications are open; selected ambassadors receive event funding, API credits, swag, resources, and community support."
     },
     {
       "slug": "cursor-campus-leads",
@@ -2359,17 +2885,23 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "6 months Cursor Ultra and event funding (applications reopen January)"
+          "type": "community",
+          "label": "Campus Lead benefits include six months of Cursor Ultra, event funding, travel support, and swag"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "student"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Be a current university student",
+          "Commit five hours per week",
+          "Complete the application and Code of Conduct"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "paused",
+      "application_state": "closed",
       "deadline": null,
       "application_url": "https://cursor.com/campus-leads",
       "official_url": "https://cursor.com/campus-leads",
@@ -2378,9 +2910,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Cursor Campus Leads page checked 2026-09-10: the program says applications will reopen in January; current page provides an interest list and lists the program benefits."
     },
     {
       "slug": "devin-ambassadors",
@@ -2394,17 +2926,24 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Community benefits"
+          "type": "community",
+          "label": "Devin Ambassador role with community events, content, and feedback opportunities"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "community_builder",
+          "developer",
+          "organizer"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Apply through the official ambassador form linked from Devin Community",
+          "Participate in community activities"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://devin.ai/community",
       "official_url": "https://devin.ai/community",
@@ -2413,9 +2952,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Devin Community page checked 2026-09-10: it links an official Ambassadors application and describes the role as leading the Devin community, hosting events, and creating content."
     },
     {
       "slug": "kimi-ambassadors",
@@ -2429,17 +2968,27 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Credits and early access"
+          "type": "community",
+          "label": "Exclusive ambassador resources, early product access, direct Kimi-team contact, and recognition"
         }
       ],
       "eligibility": {
-        "stages": [],
-        "regions": [],
-        "requirements": []
+        "stages": [
+          "developer",
+          "creator",
+          "organizer"
+        ],
+        "regions": [
+          "worldwide"
+        ],
+        "requirements": [
+          "Apply online",
+          "Participate in community building, practical AI education, or product feedback",
+          "Complete a possible interview"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "open",
       "deadline": null,
       "application_url": "https://www.kimi.ai/lp/kimi-ambassador",
       "official_url": "https://www.kimi.ai/lp/kimi-ambassador",
@@ -2448,9 +2997,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Kimi Ambassador page checked 2026-09-10: global builders, creators, and community organizers can apply; benefits include early access, resources, network, and possible collaboration/recognition."
     },
     {
       "slug": "mistral-ai-ambassadors",
@@ -2464,17 +3013,25 @@
       ],
       "benefits": [
         {
-          "type": "unspecified",
-          "label": "Studio API credits, early access"
+          "type": "community",
+          "label": "Mistral AI ambassador community, content/events participation, product feedback, and community support"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "developer",
+          "researcher",
+          "community_builder"
+        ],
         "regions": [],
-        "requirements": []
+        "requirements": [
+          "Demonstrate AI/ML and Mistral experience",
+          "Participate actively in AI/ML communities",
+          "Commit regular time to ambassador activities"
+        ]
       },
-      "status": "needs_review",
-      "application_state": "unknown",
+      "status": "active",
+      "application_state": "rolling",
       "deadline": null,
       "application_url": "https://docs.mistral.ai/community/ambassadors",
       "official_url": "https://docs.mistral.ai/community/ambassadors",
@@ -2483,9 +3040,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "official_page",
+      "verification_notes": "Official Mistral Docs page checked 2026-09-10: applications are open on a rolling basis; page lists technical, community, communication, and time-commitment requirements."
     },
     {
       "slug": "qwen-ambassadors",
@@ -2500,11 +3057,14 @@
       "benefits": [
         {
           "type": "unspecified",
-          "label": "API credits ($50–$100/month)"
+          "label": "Ambassador offer could not be re-confirmed; official URL returned no readable public content"
         }
       ],
       "eligibility": {
-        "stages": [],
+        "stages": [
+          "developer",
+          "community_builder"
+        ],
         "regions": [],
         "requirements": []
       },
@@ -2518,9 +3078,9 @@
       ],
       "separate_application": null,
       "referral_only": null,
-      "last_verified_at": null,
-      "verification_method": "readme_import",
-      "verification_notes": "Imported from the curated README; current availability and terms require manual verification."
+      "last_verified_at": "2026-09-10",
+      "verification_method": "manual_review",
+      "verification_notes": "Official URL checked 2026-09-10 but returned no readable public content; current Qwen ambassador benefits and application status require manual review."
     }
   ]
 }

--- a/data/programs.schema.json
+++ b/data/programs.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/doanbactam/awesome-builder-programs/blob/main/data/programs.schema.json",
+  "title": "Awesome Builder Programs",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "programs"],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "programs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/program"
+      }
+    }
+  },
+  "$defs": {
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "date": {
+      "type": ["string", "null"],
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "nullableBoolean": {
+      "type": ["boolean", "null"]
+    },
+    "benefit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "label"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {
+          "type": ["number", "string", "null"]
+        },
+        "currency": {
+          "type": ["string", "null"]
+        },
+        "duration": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stages", "regions", "requirements"],
+      "properties": {
+        "stages": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "regions": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "requirements": {
+          "$ref": "#/$defs/stringArray"
+        }
+      }
+    },
+    "program": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "name",
+        "provider",
+        "categories",
+        "program_type",
+        "benefits",
+        "eligibility",
+        "status",
+        "application_state",
+        "deadline",
+        "application_url",
+        "official_url",
+        "source_urls",
+        "separate_application",
+        "referral_only",
+        "last_verified_at",
+        "verification_method",
+        "verification_notes"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "categories": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": ["students", "open_source", "startups", "ai_developer_credits", "ambassadors"]
+          }
+        },
+        "program_type": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "benefits": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/benefit"
+          }
+        },
+        "eligibility": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "status": {
+          "enum": ["active", "needs_review", "paused", "expired", "unknown"]
+        },
+        "application_state": {
+          "enum": ["open", "rolling", "invite_only", "closed", "unknown"]
+        },
+        "deadline": {
+          "$ref": "#/$defs/date"
+        },
+        "application_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "official_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "source_urls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "separate_application": {
+          "$ref": "#/$defs/nullableBoolean"
+        },
+        "referral_only": {
+          "$ref": "#/$defs/nullableBoolean"
+        },
+        "last_verified_at": {
+          "$ref": "#/$defs/date"
+        },
+        "verification_method": {
+          "enum": ["readme_import", "official_page", "provider_confirmation", "manual_review", "automated_check"]
+        },
+        "verification_notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const dataPath = path.join(root, "data", "programs.json");
+const readmePath = path.join(root, "README.md");
+const checkOnly = process.argv.includes("--check");
+
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+const categories = [
+  { key: "students", heading: "Students" },
+  { key: "open_source", heading: "Open Source" },
+  { key: "startups", heading: "Startups" },
+  { key: "ai_developer_credits", heading: "AI and Developer Credits" },
+  { key: "ambassadors", heading: "Ambassadors" },
+];
+
+const statusLabels = {
+  active: "Active",
+  needs_review: "Needs review",
+  paused: "Paused",
+  expired: "Expired",
+  unknown: "Unknown",
+};
+
+const escapeCell = (value) => String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+const displayStatus = (status) => statusLabels[status] ?? status;
+const displayBenefit = (program) => program.benefits.map((benefit) => escapeCell(benefit.label)).join("<br />");
+const displayUrl = (program) => program.application_url ?? program.official_url;
+
+const lines = [
+  "# Awesome Builder Programs",
+  "",
+  '[![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <a href="https://github.com/doanbactam/awesome-builder-programs"><img src="https://img.shields.io/github/stars/doanbactam/awesome-builder-programs?style=flat" alt="Stars" /></a>',
+  "",
+  "A curated list of programs that provide credits, grants, or tools for people building things.",
+  "",
+  "Includes programs for:",
+  "",
+  "- students",
+  "- startups",
+  "- open-source maintainers",
+  "- independent developers",
+  "",
+  "Only official program pages are listed.",
+  "",
+  "Program availability and benefits can change. Verify the provider page before applying.",
+  "",
+  "The canonical structured dataset is [data/programs.json](data/programs.json).",
+  "",
+  "---",
+  "",
+  "## Contents",
+  "",
+  ...categories.map(({ heading }) => {
+    const anchor = heading.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    return "* [" + heading + "](#" + anchor + ")";
+  }),
+  "* [Data quality](#data-quality)",
+  "* [Contributing](#contributing)",
+  "",
+  "---",
+  "",
+];
+
+for (const { key, heading } of categories) {
+  const programs = data.programs
+    .filter((program) => program.categories.includes(key))
+    .sort((a, b) => a.name.localeCompare(b.name, "en", { sensitivity: "base" }));
+
+  lines.push("## " + heading, "", "| Program | Provider | Benefit | Status | Verified |", "|---|---|---|---|---|");
+  for (const program of programs) {
+    lines.push(
+      "| [" + escapeCell(program.name) + "](" + displayUrl(program) + ") | " +
+      escapeCell(program.provider) + " | " + displayBenefit(program) + " | " +
+      displayStatus(program.status) + " | " + (program.last_verified_at ?? "—") + " |",
+    );
+  }
+  lines.push("", "---", "");
+}
+
+lines.push(
+  "## Data quality",
+  "",
+  "- **Active** means an official source confirms availability and the record was verified within the last 30 days.",
+  "- **Needs review** means the record is in the curated dataset but its current availability or terms still need manual confirmation.",
+  "- **Paused** and **Expired** records are retained for provenance but are not active opportunities.",
+  "- A successful link check does not by itself prove that a program is accepting applications.",
+  "",
+  "See [DATA.md](DATA.md) for the schema and verification policy.",
+  "",
+  "---",
+  "",
+  "## Contributing",
+  "",
+  "Contributions are welcome! Edit [data/programs.json](data/programs.json) rather than editing this README directly.",
+  "",
+  "Before opening a pull request:",
+  "",
+  "- Link to the official program page",
+  "- Make sure the current status and benefit are supported by the source",
+  "- Note geographic, school, funding, or age eligibility limits when they apply",
+  "- Add last_verified_at and verification notes for active records",
+  "- Avoid affiliate or referral links",
+  "- Run node scripts/validate-programs.mjs",
+  "- Run node scripts/generate-readme.mjs",
+  "",
+  "Submit a pull request with a short explanation of the change.",
+  "",
+  "---",
+  "",
+  "## Star History",
+  "",
+  "[![Star History Chart](https://api.star-history.com/image?repos=doanbactam/awesome-builder-programs&type=date&legend=top-left)](https://www.star-history.com/?repos=doanbactam%2Fawesome-builder-programs&type=date&legend=top-left)",
+  "",
+);
+
+const generated = lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+
+if (checkOnly) {
+  const current = fs.readFileSync(readmePath, "utf8");
+  if (current !== generated) {
+    console.error("README.md is out of date. Run: node scripts/generate-readme.mjs");
+    process.exit(1);
+  }
+  console.log("README.md matches data/programs.json.");
+} else {
+  fs.writeFileSync(readmePath, generated);
+  console.log("Generated README.md from data/programs.json.");
+}

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -59,6 +59,7 @@ const lines = [
     const anchor = heading.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
     return "* [" + heading + "](#" + anchor + ")";
   }),
+  ...(data.programs.some((program) => program.status === "needs_review") ? ["* [Needs review](#needs-review)"] : []),
   "* [Data quality](#data-quality)",
   "* [Contributing](#contributing)",
   "",
@@ -68,7 +69,7 @@ const lines = [
 
 for (const { key, heading } of categories) {
   const programs = data.programs
-    .filter((program) => program.categories.includes(key))
+    .filter((program) => program.categories.includes(key) && program.status !== "needs_review")
     .sort((a, b) => a.name.localeCompare(b.name, "en", { sensitivity: "base" }));
 
   lines.push("## " + heading, "", "| Program | Provider | Benefit | Status | Verified |", "|---|---|---|---|---|");
@@ -82,11 +83,34 @@ for (const { key, heading } of categories) {
   lines.push("", "---", "");
 }
 
+const needsReview = data.programs
+  .filter((program) => program.status === "needs_review")
+  .sort((a, b) => a.name.localeCompare(b.name, "en", { sensitivity: "base" }));
+
+if (needsReview.length > 0) {
+  lines.push(
+    "## Needs review",
+    "",
+    "These records are retained because the program may still exist, but its current offer or availability could not be confirmed from a readable public source. They are not presented as active opportunities until verified.",
+    "",
+    "| Program | Provider | Benefit | Why it needs review | Checked |",
+    "|---|---|---|---|---|",
+  );
+  for (const program of needsReview) {
+    lines.push(
+      "| [" + escapeCell(program.name) + "](" + displayUrl(program) + ") | " +
+      escapeCell(program.provider) + " | " + displayBenefit(program) + " | " +
+      escapeCell(program.verification_notes) + " | " + (program.last_verified_at ?? "—") + " |",
+    );
+  }
+  lines.push("", "---", "");
+}
+
 lines.push(
   "## Data quality",
   "",
   "- **Active** means an official source confirms availability and the record was verified within the last 30 days.",
-  "- **Needs review** means the record is in the curated dataset but its current availability or terms still need manual confirmation.",
+  "- **Needs review** means the record may still exist, but its current availability or terms could not be confirmed; it is retained separately and is not an active recommendation.",
   "- **Paused** and **Expired** records are retained for provenance but are not active opportunities.",
   "- A successful link check does not by itself prove that a program is accepting applications.",
   "",

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -20,10 +20,8 @@ const categories = [
 
 const statusLabels = {
   active: "Active",
-  needs_review: "Needs review",
   paused: "Paused",
   expired: "Expired",
-  unknown: "Unknown",
 };
 
 const escapeCell = (value) => String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
@@ -59,7 +57,6 @@ const lines = [
     const anchor = heading.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
     return "* [" + heading + "](#" + anchor + ")";
   }),
-  ...(data.programs.some((program) => program.status === "needs_review") ? ["* [Needs review](#needs-review)"] : []),
   "* [Data quality](#data-quality)",
   "* [Contributing](#contributing)",
   "",
@@ -69,7 +66,7 @@ const lines = [
 
 for (const { key, heading } of categories) {
   const programs = data.programs
-    .filter((program) => program.categories.includes(key) && program.status !== "needs_review")
+    .filter((program) => program.categories.includes(key))
     .sort((a, b) => a.name.localeCompare(b.name, "en", { sensitivity: "base" }));
 
   lines.push("## " + heading, "", "| Program | Provider | Benefit | Status | Verified |", "|---|---|---|---|---|");
@@ -83,35 +80,12 @@ for (const { key, heading } of categories) {
   lines.push("", "---", "");
 }
 
-const needsReview = data.programs
-  .filter((program) => program.status === "needs_review")
-  .sort((a, b) => a.name.localeCompare(b.name, "en", { sensitivity: "base" }));
-
-if (needsReview.length > 0) {
-  lines.push(
-    "## Needs review",
-    "",
-    "These records are retained because the program may still exist, but its current offer or availability could not be confirmed from a readable public source. They are not presented as active opportunities until verified.",
-    "",
-    "| Program | Provider | Benefit | Why it needs review | Checked |",
-    "|---|---|---|---|---|",
-  );
-  for (const program of needsReview) {
-    lines.push(
-      "| [" + escapeCell(program.name) + "](" + displayUrl(program) + ") | " +
-      escapeCell(program.provider) + " | " + displayBenefit(program) + " | " +
-      escapeCell(program.verification_notes) + " | " + (program.last_verified_at ?? "—") + " |",
-    );
-  }
-  lines.push("", "---", "");
-}
-
 lines.push(
   "## Data quality",
   "",
   "- **Active** means an official source confirms availability and the record was verified within the last 30 days.",
-  "- **Needs review** means the record may still exist, but its current availability or terms could not be confirmed; it is retained separately and is not an active recommendation.",
   "- **Paused** and **Expired** records are retained for provenance but are not active opportunities.",
+  "- Unverified records (`needs_review` or `unknown`) are staging-only and are excluded from data/programs.json and this README.",
   "- A successful link check does not by itself prove that a program is accepting applications.",
   "",
   "See [DATA.md](DATA.md) for the schema and verification policy.",
@@ -125,6 +99,7 @@ lines.push(
   "Before opening a pull request:",
   "",
   "- Link to the official program page",
+  "- Verify the current benefit, eligibility, and status before adding the record; leave it out if the evidence is insufficient",
   "- Make sure the current status and benefit are supported by the source",
   "- Note geographic, school, funding, or age eligibility limits when they apply",
   "- Add last_verified_at and verification notes for active records",

--- a/scripts/validate-programs.mjs
+++ b/scripts/validate-programs.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const dataPath = path.join(root, "data", "programs.json");
+
+const allowedStatuses = new Set(["active", "needs_review", "paused", "expired", "unknown"]);
+const allowedApplicationStates = new Set(["open", "rolling", "invite_only", "closed", "unknown"]);
+const allowedCategories = new Set(["students", "open_source", "startups", "ai_developer_credits", "ambassadors"]);
+const allowedVerificationMethods = new Set([
+  "readme_import",
+  "official_page",
+  "provider_confirmation",
+  "manual_review",
+  "automated_check",
+]);
+
+const errors = [];
+const error = (message) => errors.push(message);
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const isNonEmptyString = (value) => typeof value === "string" && value.trim().length > 0;
+
+function isHttpUrl(value) {
+  if (!isNonEmptyString(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isIsoDate(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(value + "T00:00:00Z");
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function ageInDays(date) {
+  const then = Date.parse(date + "T00:00:00Z");
+  return Math.floor((Date.now() - then) / 86_400_000);
+}
+
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+} catch (cause) {
+  console.error("Unable to read " + path.relative(root, dataPath) + ": " + cause.message);
+  process.exit(1);
+}
+
+if (!isRecord(data)) error("Root value must be an object.");
+if (!isNonEmptyString(data?.$schema)) error("$schema must point to the data schema.");
+if (data?.schema_version !== 1) error("schema_version must be 1.");
+if (!Array.isArray(data?.programs) || data.programs.length === 0) {
+  error("programs must be a non-empty array.");
+}
+
+const slugs = new Set();
+const identities = new Set();
+
+for (const [index, program] of (data?.programs ?? []).entries()) {
+  const label = "programs[" + index + "]";
+
+  if (!isRecord(program)) {
+    error(label + " must be an object.");
+    continue;
+  }
+
+  for (const field of ["slug", "name", "provider", "status", "application_state", "verification_method", "verification_notes"]) {
+    if (!isNonEmptyString(program[field])) error(label + "." + field + " must be a non-empty string.");
+  }
+
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(program.slug ?? "")) {
+    error(label + ".slug must be kebab-case.");
+  }
+  if (slugs.has(program.slug)) error(label + ".slug is duplicated: " + program.slug);
+  slugs.add(program.slug);
+
+  const identity = String(program.provider) + String.fromCharCode(0) + String(program.name);
+  if (identities.has(identity)) error(label + " duplicates provider/name: " + program.provider + " / " + program.name);
+  identities.add(identity);
+
+  for (const field of ["categories", "program_type"]) {
+    if (!Array.isArray(program[field]) || program[field].length === 0 || program[field].some((value) => !isNonEmptyString(value))) {
+      error(label + "." + field + " must be a non-empty array of strings.");
+    }
+  }
+  if (Array.isArray(program.categories)) {
+    for (const category of program.categories) {
+      if (!allowedCategories.has(category)) error(label + ".categories contains an unknown category: " + category);
+    }
+  }
+
+  if (!Array.isArray(program.benefits) || program.benefits.length === 0) {
+    error(label + ".benefits must be a non-empty array.");
+  } else {
+    for (const [benefitIndex, benefit] of program.benefits.entries()) {
+      if (!isRecord(benefit) || !isNonEmptyString(benefit.type) || !isNonEmptyString(benefit.label)) {
+        error(label + ".benefits[" + benefitIndex + "] needs non-empty type and label fields.");
+      }
+    }
+  }
+
+  if (!isRecord(program.eligibility)) {
+    error(label + ".eligibility must be an object.");
+  } else {
+    for (const field of ["stages", "regions", "requirements"]) {
+      if (!Array.isArray(program.eligibility[field]) || program.eligibility[field].some((value) => !isNonEmptyString(value))) {
+        error(label + ".eligibility." + field + " must be an array of strings.");
+      }
+    }
+  }
+
+  if (!allowedStatuses.has(program.status)) {
+    error(label + ".status is invalid: " + program.status);
+  }
+  if (!allowedApplicationStates.has(program.application_state)) {
+    error(label + ".application_state is invalid: " + program.application_state);
+  }
+  if (!allowedVerificationMethods.has(program.verification_method)) {
+    error(label + ".verification_method is invalid: " + program.verification_method);
+  }
+
+  if (!isHttpUrl(program.official_url)) error(label + ".official_url must be an HTTP(S) URL.");
+  if (!isHttpUrl(program.application_url)) error(label + ".application_url must be an HTTP(S) URL.");
+
+  if (!Array.isArray(program.source_urls) || program.source_urls.length === 0 || program.source_urls.some((url) => !isHttpUrl(url))) {
+    error(label + ".source_urls must contain at least one HTTP(S) URL.");
+  } else if (!program.source_urls.includes(program.official_url)) {
+    error(label + ".source_urls must include official_url.");
+  }
+
+  if (program.deadline !== null && !isIsoDate(program.deadline)) {
+    error(label + ".deadline must be an ISO date or null.");
+  }
+  if (program.last_verified_at !== null && !isIsoDate(program.last_verified_at)) {
+    error(label + ".last_verified_at must be an ISO date or null.");
+  }
+  for (const field of ["separate_application", "referral_only"]) {
+    if (program[field] !== null && typeof program[field] !== "boolean") {
+      error(label + "." + field + " must be boolean or null.");
+    }
+  }
+
+  if (program.status === "active") {
+    if (program.last_verified_at === null) {
+      error(label + " marked active without last_verified_at.");
+    } else if (ageInDays(program.last_verified_at) > 30) {
+      error(label + " has not been verified within 30 days.");
+    }
+    if (program.verification_method === "readme_import") {
+      error(label + " marked active with readme_import verification.");
+    }
+  }
+  if (["paused", "expired"].includes(program.status) && !isNonEmptyString(program.verification_notes)) {
+    error(label + "." + program.status + " records need verification_notes.");
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Program data validation failed with " + errors.length + " error(s):");
+  for (const message of errors) console.error("- " + message);
+  process.exit(1);
+}
+
+const counts = Object.fromEntries([...allowedStatuses].map((status) => [status, 0]));
+for (const program of data.programs) counts[program.status] += 1;
+const summary = [...allowedStatuses]
+  .filter((status) => counts[status] > 0)
+  .map((status) => counts[status] + " " + status)
+  .join(", ");
+console.log("Validated " + data.programs.length + " programs (" + summary + ").");

--- a/scripts/validate-programs.mjs
+++ b/scripts/validate-programs.mjs
@@ -118,6 +118,9 @@ for (const [index, program] of (data?.programs ?? []).entries()) {
   if (!allowedStatuses.has(program.status)) {
     error(label + ".status is invalid: " + program.status);
   }
+  if (["needs_review", "unknown"].includes(program.status)) {
+    error(label + ".status is not publishable; verify the record and use active, paused, or expired.");
+  }
   if (!allowedApplicationStates.has(program.application_state)) {
     error(label + ".application_state is invalid: " + program.application_state);
   }


### PR DESCRIPTION
## Summary

- Maintain `data/programs.json` as the canonical structured dataset and generate README tables from it.
- Publish only programs whose current benefit, eligibility, and status are supported by an official source.
- Re-review the previously uncertain candidates using official pages, documentation, and live dynamic pages.
- Keep verified but currently closed opportunities (such as the 2026 GSoC cycle) as `paused`; exclude candidates that still lack enough current official evidence.
- Make the validator reject `needs_review` and `unknown` statuses so unreviewed records cannot enter the public dataset.

## Second-pass review

- Updated: Google AI Pro for Students, Google Summer of Code, JetBrains Student Pack, LFX Mentorship, Mixpanel, Z.AI Startups, Qwen Ambassadors, and Sentry for Startups.
- Excluded from the canonical list: Atlas Cloud for Open Source, PlanetScale for Startups, and Hugging Face Startups. Their current official pages did not expose enough program-specific terms to publish safely; this is not a claim that the programs do not exist.

## Validation

- `node scripts/validate-programs.mjs`
- `node scripts/generate-readme.mjs --check`
- `git diff --check`
- Check links workflow
- Validate program data workflow

Current dataset: 69 reviewed records (63 active, 6 paused), with no `needs_review` or `unknown` records.